### PR TITLE
feat: Development Requester selection context (Issue 7)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,60 +1,126 @@
-import { useState } from "react";
-import { checkSystem, Category } from "./api.js";
+import { useEffect, useState } from "react";
+import {
+  fetchDevelopmentRequesters,
+  DevelopmentRequester,
+} from "./api.js";
 
-// UI states: idle, loading, success, error.
-type UiState = "idle" | "loading" | "success" | "error";
+// Requester selection screen for Lab 2 testing (NOT a real login screen).
+// Authentication and role-based access arrive in Lab 3.
+function RequesterSelection({ onSelect }: { onSelect: (r: DevelopmentRequester) => void }) {
+  const [status, setStatus] = useState<"loading" | "empty" | "error" | "ready">("loading");
+  const [requesterId, setRequesterId] = useState("");
+  const [requesters, setRequesters] = useState<DevelopmentRequester[]>([]);
 
-export default function App() {
-  const [state, setState] = useState<UiState>("idle");
-  const [categories, setCategories] = useState<Category[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    setStatus("loading");
+    fetchDevelopmentRequesters()
+      .then((items) => {
+        if (cancelled) return;
+        setRequesters(items);
+        setStatus(items.length === 0 ? "empty" : "ready");
+      })
+      .catch(() => {
+        if (!cancelled) setStatus("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
-  async function handleCheck() {
-    setState("loading");
-    try {
-      const result = await checkSystem();
-      setCategories(result.categories);
-      setState("success");
-    } catch {
-      setState("error");
-    }
+  function handleContinue() {
+    const requester = requesters.find((r) => String(r.id) === requesterId);
+    if (requester) onSelect(requester);
   }
 
   return (
     <div className="container py-5" style={{ maxWidth: 640 }}>
-      <h1 className="h3 mb-4">
+      <h1 className="h3 mb-1">
         TokTickIT <span className="text-success">IT Service Desk</span>
       </h1>
+      <p className="text-muted mb-4">
+        Select a Development Requester to test requester-specific ticket behavior. This is not a
+        login screen; authentication and role-based access will be introduced in Lab 3.
+      </p>
 
-      <button className="btn btn-success" onClick={handleCheck} disabled={state === "loading"}>
-        {state === "loading" ? "Loading…" : "Check System"}
-      </button>
+      {status === "loading" && <p className="text-secondary">Loading development requesters…</p>}
 
-      {state === "loading" && <p className="mt-3 text-secondary">Loading…</p>}
-
-      {state === "success" && (
-        <div className="mt-3">
-          <p className="mb-1">
-            <strong>System Status:</strong> <span className="text-success">Online</span>
-          </p>
-          <p className="mb-1">
-            <strong>Supported Request Categories:</strong>
-          </p>
-          <ol className="mb-0">
-            {categories.map((c) => (
-              <li key={c.id}>{c.name}</li>
-            ))}
-          </ol>
-        </div>
+      {status === "empty" && (
+        <p className="text-warning">There are no active development requesters.</p>
       )}
 
-      {state === "error" && (
-        <div className="mt-3">
-          <p className="mb-1">
-            <strong>System Status:</strong> <span className="text-danger">Offline</span>
-          </p>
-          <p className="text-danger mb-0">Unable to connect to TokTickIT API</p>
-        </div>
+      {status === "error" && (
+        <p className="text-danger">
+          Unable to load development requesters. Please try again later.
+        </p>
       )}
+
+      {status === "ready" && (
+        <form
+          className="g-3"
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleContinue();
+          }}
+        >
+          <div className="mb-3">
+            <label htmlFor="development-requester" className="form-label">
+              Development Requester
+            </label>
+            <select
+              id="development-requester"
+              className="form-select"
+              value={requesterId}
+              onChange={(e) => setRequesterId(e.target.value)}
+            >
+              <option value="">Select a requester…</option>
+              {requesters.map((r) => (
+                <option key={r.id} value={r.id}>
+                  {r.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <button
+            type="submit"
+            className="btn btn-success"
+            disabled={requesterId === ""}
+          >
+            Continue
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}
+
+export default function App() {
+  const [selected, setSelected] = useState<DevelopmentRequester | null>(null);
+
+  if (selected === null) {
+    return <RequesterSelection onSelect={setSelected} />;
+  }
+
+  return (
+    <div className="container py-5" style={{ maxWidth: 640 }}>
+      <h1 className="h3 mb-1">
+        TokTickIT <span className="text-success">IT Service Desk</span>
+      </h1>
+      <p className="mb-4">
+        Selected Requester:{" "}
+        <strong>{selected.name}</strong>{" "}
+        <button
+          type="button"
+          className="btn btn-outline-secondary btn-sm ms-2"
+          onClick={() => setSelected(null)}
+        >
+          Change Requester
+        </button>
+      </p>
+      <p className="text-secondary">
+        Ticket screens (Create Ticket, My Tickets, Ticket Detail) are implemented in the next
+        Lab 2 issues.
+      </p>
     </div>
   );
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -5,6 +5,12 @@ export interface Category {
   name: string;
 }
 
+export interface DevelopmentRequester {
+  id: number;
+  name: string;
+  email: string;
+}
+
 export interface SystemStatus {
   online: boolean;
   categories: Category[];
@@ -22,4 +28,12 @@ export async function checkSystem(): Promise<SystemStatus> {
   if (!categoriesRes.ok) throw new Error("Unable to load categories");
   const categories: Category[] = await categoriesRes.json();
   return { online: true, categories };
+}
+
+// Issue 7 — Development Requester context (testing-only "login").
+export async function fetchDevelopmentRequesters(): Promise<DevelopmentRequester[]> {
+  const res = await fetch(`${API_URL}/api/development-requesters`);
+  if (!res.ok) throw new Error("Unable to load development requesters");
+  const body: { items: DevelopmentRequester[] } = await res.json();
+  return body.items;
 }

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -6,36 +6,34 @@ import * as api from "../../src/api.js";
 
 describe("App", () => {
   it("renders the TokTickIT heading", () => {
+    vi.spyOn(api, "fetchDevelopmentRequesters").mockResolvedValue([]);
     render(<App />);
     expect(screen.getByText(/TokTickIT/i)).toBeInTheDocument();
   });
 
-  it("shows Online and the seeded categories on success", async () => {
-    vi.spyOn(api, "checkSystem").mockResolvedValue({
-      online: true,
-      categories: [
-        { id: 1, name: "Account and Access" },
-        { id: 2, name: "Hardware" },
-        { id: 3, name: "Software" },
-        { id: 4, name: "Network" },
-      ],
-    });
+  it("enters the shell only after a Development Requester is selected", async () => {
+    vi.spyOn(api, "fetchDevelopmentRequesters").mockResolvedValue([
+      { id: 1, name: "Alice Anderson", email: "alice.anderson@example.com" },
+    ]);
     const user = userEvent.setup();
     render(<App />);
-    await user.click(screen.getByRole("button", { name: /Check System/i }));
-    expect(await screen.findByText(/Online/i)).toBeInTheDocument();
-    expect(screen.getByText("Account and Access")).toBeInTheDocument();
-    expect(screen.getByText("Hardware")).toBeInTheDocument();
-    expect(screen.getByText("Software")).toBeInTheDocument();
-    expect(screen.getByText("Network")).toBeInTheDocument();
+
+    const combobox = await screen.findByRole("combobox", {
+      name: /Development Requester/i,
+    });
+    await user.selectOptions(combobox, "1");
+    await user.click(screen.getByRole("button", { name: /Continue/i }));
+
+    expect(await screen.findByText(/Selected Requester/i)).toBeInTheDocument();
+    expect(screen.getByText("Alice Anderson")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Change Requester/i })).toBeInTheDocument();
   });
 
-  it("shows an Offline error message when the API is unavailable", async () => {
-    vi.spyOn(api, "checkSystem").mockRejectedValue(new Error("network down"));
-    const user = userEvent.setup();
+  it("returns to the requester selection screen when the API is unavailable", async () => {
+    vi.spyOn(api, "fetchDevelopmentRequesters").mockRejectedValue(new Error("network down"));
     render(<App />);
-    await user.click(screen.getByRole("button", { name: /Check System/i }));
-    expect(await screen.findByText(/Offline/i)).toBeInTheDocument();
-    expect(screen.getByText(/Unable to connect to TokTickIT API/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Unable to load development requesters/i)
+    ).toBeInTheDocument();
   });
 });

--- a/client/tests/lab-02/RequesterSelection.test.tsx
+++ b/client/tests/lab-02/RequesterSelection.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import App from "../../src/App.js";
+import * as api from "../../src/api.js";
+
+const ACTIVE_REQUESTERS = [
+  { id: 1, name: "Alice Anderson", email: "alice.anderson@example.com" },
+  { id: 2, name: "Bob Brown", email: "bob.brown@example.com" },
+  { id: 3, name: "Carol Chen", email: "carol.chen@example.com" },
+  { id: 4, name: "David Diaz", email: "david.diaz@example.com" },
+];
+
+describe("App shell - Development Requester Selection", () => {
+  it("shows the requester selection screen when no requester is selected", async () => {
+    vi.spyOn(api, "fetchDevelopmentRequesters").mockResolvedValue(ACTIVE_REQUESTERS);
+    render(<App />);
+    expect(screen.getByText(/TokTickIT/i)).toBeInTheDocument();
+    expect(screen.getByText(/lab 3/i)).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: /Continue/i })
+    ).toBeInTheDocument();
+  });
+
+  it("shows a loading state while requesters are being fetched", () => {
+    let resolveFn!: (v: api.DevelopmentRequester[]) => void;
+    vi.spyOn(api, "fetchDevelopmentRequesters").mockReturnValue(
+      new Promise((resolve) => {
+        resolveFn = resolve;
+      })
+    );
+    render(<App />);
+    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+    resolveFn(ACTIVE_REQUESTERS);
+  });
+
+  it("shows an empty state when there are no active requesters", async () => {
+    vi.spyOn(api, "fetchDevelopmentRequesters").mockResolvedValue([]);
+    render(<App />);
+    expect(await screen.findByText(/no active development requesters/i)).toBeInTheDocument();
+  });
+
+  it("shows a safe error state when the API fails", async () => {
+    vi.spyOn(api, "fetchDevelopmentRequesters").mockRejectedValue(new Error("network down"));
+    render(<App />);
+    expect(await screen.findByText(/unable to load development requesters/i)).toBeInTheDocument();
+  });
+
+  it("stores the selected requester and shows it in the shell with a Change Requester action", async () => {
+    vi.spyOn(api, "fetchDevelopmentRequesters").mockResolvedValue(ACTIVE_REQUESTERS);
+    const user = userEvent.setup();
+    render(<App />);
+
+    const combobox = await screen.findByRole("combobox", {
+      name: /Development Requester/i,
+    });
+    await user.selectOptions(combobox, "2");
+    await user.click(screen.getByRole("button", { name: /Continue/i }));
+
+    expect(await screen.findByText(/Selected Requester/i)).toBeInTheDocument();
+    expect(screen.getByText("Bob Brown")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Change Requester/i })).toBeInTheDocument();
+  });
+
+  it("returns to the selection screen when Change Requester is pressed", async () => {
+    vi.spyOn(api, "fetchDevelopmentRequesters").mockResolvedValue(ACTIVE_REQUESTERS);
+    const user = userEvent.setup();
+    render(<App />);
+
+    const combobox = await screen.findByRole("combobox", {
+      name: /Development Requester/i,
+    });
+    await user.selectOptions(combobox, "1");
+    await user.click(screen.getByRole("button", { name: /Continue/i }));
+
+    await user.click(await screen.findByRole("button", { name: /Change Requester/i }));
+    expect(
+      await screen.findByRole("combobox", { name: /Development Requester/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -35,4 +35,23 @@ app.get("/api/categories", async (_req: Request, res: Response) => {
   }
 });
 
+// ---------------------------------------------------------------------------
+// Issue 7 — Development Requester context (testing-only "login")
+// GET /api/development-requesters -> only ACTIVE requesters, in id order.
+// The inactive requester must never appear in the selection dropdown.
+// ---------------------------------------------------------------------------
+app.get("/api/development-requesters", async (_req: Request, res: Response) => {
+  try {
+    const requesters = await getPrisma().developmentRequester.findMany({
+      where: { active: true },
+      orderBy: { id: "asc" },
+    });
+    res.status(200).json({
+      items: requesters.map(({ id, name, email }) => ({ id, name, email })),
+    });
+  } catch {
+    res.status(500).json({ error: "Unable to load development requesters" });
+  }
+});
+
 export default app;

--- a/server/tests/lab-02/dev-requester.api.test.ts
+++ b/server/tests/lab-02/dev-requester.api.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, afterAll } from "vitest";
+import request from "supertest";
+import { getPrisma } from "../../src/prisma.js";
+import { app } from "../../src/app.js";
+import { seedRequesters, REQUESTERS } from "../../prisma/seed.js";
+
+describe("GET /api/development-requesters", () => {
+  afterAll(async () => {
+    // Restore the idempotent seed state after the tests that mutate it.
+    await seedRequesters(getPrisma());
+  });
+
+  it("returns only active requesters", async () => {
+    const res = await request(app).get("/api/development-requesters");
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.items)).toBe(true);
+
+    const names = res.body.items.map((r: { name: string }) => r.name);
+    expect(names).toContain("Alice Anderson");
+    expect(names).not.toContain("Evan Ellis"); // inactive
+  });
+
+  it("returns each active requester with id, name, and email", async () => {
+    const res = await request(app).get("/api/development-requesters");
+    const active = REQUESTERS.filter((r) => r.active);
+    expect(res.body.items).toHaveLength(active.length);
+    for (const item of res.body.items) {
+      expect(item).toHaveProperty("id");
+      expect(typeof item.name).toBe("string");
+      expect(typeof item.email).toBe("string");
+    }
+  });
+
+  it("returns an empty items array when no active requesters exist", async () => {
+    const prisma = getPrisma();
+    await prisma.developmentRequester.deleteMany();
+
+    const res = await request(app).get("/api/development-requesters");
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+  });
+});


### PR DESCRIPTION
Addresses #15 (Issue 7: Development Requester Selection).

## Backend
- `GET /api/development-requesters` returns only **active** requesters (inactive excluded, BR-02), each `{ id, name, email }`.
- Response shape per api-spec.md: `{ items: [...] }`.

## Frontend
- **Requester selection screen** (Lab 2 testing mechanism, clearly NOT a login):
  - TokTickIT title + explanation that auth comes in Lab 3
  - Development Requester dropdown populated from PostgreSQL
  - Continue button, keyboard-accessible form controls
  - loading, empty (no active requesters), and safe API-failure states
- **Application shell** after selection: displays the selected requester's name + a **Change Requester** action that returns to the selection screen.

## Tests
- server `lab-02/dev-requester.api.test.ts`: active-only, shape, empty state (3 tests)
- client `lab-02/RequesterSelection.test.tsx`: selection screen, loading, empty, failure, select + shell, change requester (6 tests)
- Updated Lab 1 `App.test.tsx` to the new requester-first flow so the suite stays green.

## Verification
- `cd server && npm test` → **15/15 passing**
- `cd client && npm test` → **9/9 passing**
- `tsc --noEmit` clean on both sides.

**Not merged — awaiting peer review.**