### PR TITLE
feat: Ticket creation (API + Create Ticket screen) (Issue 8)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import {
   fetchDevelopmentRequesters,
   DevelopmentRequester,
 } from "./api.js";
+import CreateTicket from "./CreateTicket.js";
 
 // Requester selection screen for Lab 2 testing (NOT a real login screen).
 // Authentication and role-based access arrive in Lab 3.
@@ -102,25 +103,33 @@ export default function App() {
   }
 
   return (
-    <div className="container py-5" style={{ maxWidth: 640 }}>
-      <h1 className="h3 mb-1">
-        TokTickIT <span className="text-success">IT Service Desk</span>
-      </h1>
-      <p className="mb-4">
-        Selected Requester:{" "}
-        <strong>{selected.name}</strong>{" "}
-        <button
-          type="button"
-          className="btn btn-outline-secondary btn-sm ms-2"
-          onClick={() => setSelected(null)}
-        >
-          Change Requester
-        </button>
-      </p>
-      <p className="text-secondary">
-        Ticket screens (Create Ticket, My Tickets, Ticket Detail) are implemented in the next
-        Lab 2 issues.
-      </p>
+    <div className="app-shell">
+      <header className="app-header py-3 mb-4" style={{ background: "#006B3C" }}>
+        <div className="container" style={{ maxWidth: 720 }}>
+          <div className="d-flex justify-content-between align-items-center flex-wrap gap-2">
+            <div>
+              <h1 className="h4 mb-0 text-white">
+                TokTickIT <span className="opacity-75">IT Service Desk</span>
+              </h1>
+              <div className="text-white-50 small">
+                Selected Requester: <strong className="text-white">{selected.name}</strong>
+              </div>
+            </div>
+            <button
+              type="button"
+              className="btn btn-sm btn-success"
+              onClick={() => setSelected(null)}
+              style={{ background: "#0B7A46", borderColor: "#0B7A46" }}
+            >
+              Change Requester
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <div className="container" style={{ maxWidth: 720 }}>
+        <CreateTicket requester={selected} />
+      </div>
     </div>
   );
 }

--- a/client/src/CreateTicket.tsx
+++ b/client/src/CreateTicket.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useState } from "react";
+import {
+  Category,
+  RelatedSystem,
+  DevelopmentRequester,
+  Priority,
+  Ticket,
+  createTicket,
+  fetchCategories,
+  fetchRelatedSystems,
+} from "./api.js";
+
+const PRIORITIES: Priority[] = ["LOW", "MEDIUM", "HIGH", "URGENT"];
+
+interface Props {
+  requester: DevelopmentRequester;
+}
+
+type FormState = "idle" | "loading" | "submitting" | "success" | "failure";
+
+export default function CreateTicket({ requester }: Props) {
+  const [formState, setFormState] = useState<FormState>("idle");
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [relatedSystems, setRelatedSystems] = useState<RelatedSystem[]>([]);
+  const [fieldsError, setFieldsError] = useState<Record<string, string>>({});
+
+  const [summary, setSummary] = useState("");
+  const [description, setDescription] = useState("");
+  const [categoryId, setCategoryId] = useState("");
+  const [relatedSystemId, setRelatedSystemId] = useState("");
+  const [requestedPriority, setRequestedPriority] = useState<Priority>("MEDIUM");
+  const [created, setCreated] = useState<Ticket | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([fetchCategories(), fetchRelatedSystems()])
+      .then(([cats, systems]) => {
+        if (cancelled) return;
+        setCategories(cats);
+        setRelatedSystems(systems);
+        setFormState(cats.length === 0 && systems.length === 0 ? "failure" : "idle");
+      })
+      .catch(() => {
+        if (!cancelled) setFormState("failure");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const local: Record<string, string> = {};
+    if (summary.trim() === "") local.summary = "Summary is required.";
+    if (description.trim() === "") local.description = "Description is required.";
+    if (categoryId === "") local.categoryId = "Category is required.";
+    if (relatedSystemId === "") local.relatedSystemId = "Related System is required.";
+    setFieldsError(local);
+    if (Object.keys(local).length > 0) return;
+
+    setFormState("submitting");
+    setFieldsError({});
+    try {
+      const ticket = await createTicket({
+        requesterId: requester.id,
+        summary: summary.trim(),
+        description: description.trim(),
+        categoryId: Number(categoryId),
+        relatedSystemId: Number(relatedSystemId),
+        requestedPriority,
+      });
+      setCreated(ticket);
+      setFormState("success");
+    } catch (err) {
+      const e = err as Error & { fields?: Record<string, string> };
+      setFieldsError(e.fields ?? {});
+      setFormState("failure");
+    }
+  }
+
+  return (
+    <div className="container py-4" style={{ maxWidth: 720 }}>
+      <h2 className="h4 mb-3">Create Ticket</h2>
+
+      {formState === "loading" && <p className="text-secondary">Loading…</p>}
+
+      {formState === "failure" && Object.keys(fieldsError).length === 0 && (
+        <p className="text-danger">
+          Unable to load reference data. Please try again later.
+        </p>
+      )}
+
+      {formState === "success" && created && (
+        <div className="alert alert-success">
+          <strong>Ticket created.</strong> Official Ticket Number:
+          <span className="fw-bold"> {created.ticketNumber}</span>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit}>
+        <fieldset disabled={formState === "submitting"}>
+          {/* System-generated read-only values */}
+          <div className="row g-3 mb-3">
+            <div className="col-6">
+              <label htmlFor="ticket-system" className="form-label">
+                Ticket Number
+              </label>
+              <input
+                id="ticket-system"
+                className="form-control readonly-field"
+                value="Generated on submission"
+                readOnly
+              />
+            </div>
+            <div className="col-6">
+              <label htmlFor="ticket-status-system" className="form-label">
+                Current Status
+              </label>
+              <input
+                id="ticket-status-system"
+                className="form-control readonly-field"
+                value="SUBMITTED"
+                readOnly
+              />
+            </div>
+          </div>
+
+          {/* Requester (read-only, from selection) */}
+          <div className="mb-3">
+            <label htmlFor="requester-readonly" className="form-label">
+              Development Requester
+            </label>
+            <input
+              id="requester-readonly"
+              className="form-control readonly-field"
+              value={`${requester.name} (${requester.email})`}
+              readOnly
+            />
+          </div>
+
+          {/* Classification fields */}
+          <div className="row g-3 mb-3">
+            <div className="col-md-4">
+              <label htmlFor="categoryId" className="form-label">
+                Category <span className="text-danger">*</span>
+              </label>
+              <select
+                id="categoryId"
+                className="form-select"
+                value={categoryId}
+                onChange={(e) => setCategoryId(e.target.value)}
+              >
+                <option value="">Select…</option>
+                {categories.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+              {fieldsError.categoryId && (
+                <small className="text-danger d-block">{fieldsError.categoryId}</small>
+              )}
+            </div>
+            <div className="col-md-4">
+              <label htmlFor="relatedSystemId" className="form-label">
+                Related System <span className="text-danger">*</span>
+              </label>
+              <select
+                id="relatedSystemId"
+                className="form-select"
+                value={relatedSystemId}
+                onChange={(e) => setRelatedSystemId(e.target.value)}
+              >
+                <option value="">Select…</option>
+                {relatedSystems.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.name}
+                  </option>
+                ))}
+              </select>
+              {fieldsError.relatedSystemId && (
+                <small className="text-danger d-block">{fieldsError.relatedSystemId}</small>
+              )}
+            </div>
+            <div className="col-md-4">
+              <label htmlFor="requestedPriority" className="form-label">
+                Requested Priority
+              </label>
+              <select
+                id="requestedPriority"
+                className="form-select"
+                value={requestedPriority}
+                onChange={(e) => setRequestedPriority(e.target.value as Priority)}
+              >
+                {PRIORITIES.map((p) => (
+                  <option key={p} value={p}>
+                    {p}
+                  </option>
+                ))}
+              </select>
+              {fieldsError.requestedPriority && (
+                <small className="text-danger d-block">{fieldsError.requestedPriority}</small>
+              )}
+            </div>
+          </div>
+
+          {/* Summary and Description */}
+          <div className="mb-3">
+            <label htmlFor="summary" className="form-label">
+              Summary <span className="text-danger">*</span>
+            </label>
+            <input
+              id="summary"
+              className={`form-control ${fieldsError.summary ? "is-invalid" : ""}`}
+              value={summary}
+              onChange={(e) => setSummary(e.target.value)}
+              placeholder="Brief description of the issue"
+            />
+            {fieldsError.summary && (
+              <small className="text-danger d-block">{fieldsError.summary}</small>
+            )}
+          </div>
+
+          <div className="mb-3">
+            <label htmlFor="description" className="form-label">
+              Description <span className="text-danger">*</span>
+            </label>
+            <textarea
+              id="description"
+              className={`form-control ${fieldsError.description ? "is-invalid" : ""}`}
+              rows={5}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Describe the issue in detail"
+            />
+            {fieldsError.description && (
+              <small className="text-danger d-block">{fieldsError.description}</small>
+            )}
+          </div>
+        </fieldset>
+
+        {formState === "failure" && Object.keys(fieldsError).length > 0 && (
+          <p className="text-danger">Please correct the highlighted fields and try again.</p>
+        )}
+        {formState === "failure" && Object.keys(fieldsError).length === 0 && (
+          <p className="text-danger">
+            Unable to create the ticket. Your entered values were preserved; please try again.
+          </p>
+        )}
+
+        <button
+          type="submit"
+          className="btn btn-success"
+          disabled={formState === "submitting"}
+        >
+          {formState === "submitting" ? "Submitting…" : "Submit Ticket"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -5,6 +5,12 @@ export interface Category {
   name: string;
 }
 
+export interface RelatedSystem {
+  id: number;
+  name: string;
+  type: string;
+}
+
 export interface DevelopmentRequester {
   id: number;
   name: string;
@@ -14,6 +20,32 @@ export interface DevelopmentRequester {
 export interface SystemStatus {
   online: boolean;
   categories: Category[];
+}
+
+export type Priority = "LOW" | "MEDIUM" | "HIGH" | "URGENT";
+
+export interface Ticket {
+  ticketNumber: string;
+  id: number;
+  summary: string;
+  description: string;
+  requesterId: number;
+  category: { id: number; name: string };
+  relatedSystem: { id: number; name: string };
+  requestedPriority: Priority;
+  itPriority: Priority;
+  currentStatus: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateTicketInput {
+  requesterId: number;
+  summary: string;
+  description: string;
+  categoryId: number;
+  relatedSystemId: number;
+  requestedPriority: Priority;
 }
 
 // Issue 2 + Issue 4 — call the backend.
@@ -36,4 +68,38 @@ export async function fetchDevelopmentRequesters(): Promise<DevelopmentRequester
   if (!res.ok) throw new Error("Unable to load development requesters");
   const body: { items: DevelopmentRequester[] } = await res.json();
   return body.items;
+}
+
+// Issue 8 — reference data for the Create Ticket form.
+export async function fetchCategories(): Promise<Category[]> {
+  const res = await fetch(`${API_URL}/api/categories`);
+  if (!res.ok) throw new Error("Unable to load categories");
+  return (await res.json()) as Category[];
+}
+
+export async function fetchRelatedSystems(): Promise<RelatedSystem[]> {
+  const res = await fetch(`${API_URL}/api/related-systems`);
+  if (!res.ok) throw new Error("Unable to load related systems");
+  const body: { items: RelatedSystem[] } = await res.json();
+  return body.items;
+}
+
+// Issue 8 — create a validated Ticket.
+export async function createTicket(
+  input: CreateTicketInput
+): Promise<Ticket> {
+  const res = await fetch(`${API_URL}/api/tickets`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const err = new Error("Unable to create ticket") as Error & {
+      fields?: Record<string, string>;
+    };
+    if (body?.error?.fields) err.fields = body.error.fields;
+    throw err;
+  }
+  return body.ticket as Ticket;
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -90,7 +90,10 @@ export async function createTicket(
 ): Promise<Ticket> {
   const res = await fetch(`${API_URL}/api/tickets`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      "X-Requester-Id": String(input.requesterId),
+    },
     body: JSON.stringify(input),
   });
   const body = await res.json().catch(() => ({}));

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "bootstrap/dist/css/bootstrap.min.css";
+import "./styles.css";
 import App from "./App.js";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1,0 +1,21 @@
+/* TokTickIT Zen Green UI (ui-spec.md) — reusable presentation rules. */
+
+:root {
+  --tok-primary: #006b3c;
+  --tok-secondary: #0b7a46;
+  --tok-pale: #eaf6ef;
+  --tok-bg: #f5f7f6;
+  --tok-text: #1c2b22;
+  --tok-readonly: #eef2f0;
+}
+
+body {
+  background-color: var(--tok-bg);
+  color: var(--tok-text);
+}
+
+/* Read-only fields must be visually distinct from editable ones. */
+.readonly-field {
+  background-color: var(--tok-readonly) !important;
+  color: var(--tok-text);
+}

--- a/client/tests/lab-02/CreateTicket.test.tsx
+++ b/client/tests/lab-02/CreateTicket.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CreateTicket from "../../src/CreateTicket.js";
+import * as api from "../../src/api.js";
+
+const REQUIRE = { requester: { id: 1, name: "Alice Anderson", email: "alice@example.com" } } as const;
+
+const CATEGORIES = [
+  { id: 1, name: "Hardware" },
+  { id: 2, name: "Software" },
+];
+
+const SYSTEMS = [
+  { id: 1, name: "ERP System", type: "Application" },
+  { id: 2, name: "Email Server", type: "Infrastructure" },
+];
+
+const TICKET = {
+  ticketNumber: "TK-000001",
+  id: 1,
+  summary: "Laptop battery drains quickly",
+  description: "Battery drops fast.",
+  requesterId: 1,
+  category: { id: 1, name: "Hardware" },
+  relatedSystem: { id: 1, name: "ERP System" },
+  requestedPriority: "MEDIUM" as const,
+  itPriority: "MEDIUM" as const,
+  currentStatus: "SUBMITTED",
+  createdAt: "2026-09-01T00:00:00.000Z",
+  updatedAt: "2026-09-01T00:00:00.000Z",
+};
+
+describe("CreateTicket", () => {
+  beforeEach(() => {
+    vi.spyOn(api, "fetchCategories").mockResolvedValue(CATEGORIES);
+    vi.spyOn(api, "fetchRelatedSystems").mockResolvedValue(SYSTEMS);
+  });
+
+  it("shows field-level messages and does not call the API on invalid submit (UI-01)", async () => {
+    const createSpy = vi.spyOn(api, "createTicket").mockResolvedValue(TICKET);
+    const user = userEvent.setup();
+    render(<CreateTicket {...REQUIRE} />);
+
+    await user.click(
+      await screen.findByRole("button", { name: /Submit Ticket/i })
+    );
+
+    expect(await screen.findByText(/Summary is required/i)).toBeInTheDocument();
+    expect(screen.getByText(/Description is required/i)).toBeInTheDocument();
+    expect(screen.getByText(/Category is required/i)).toBeInTheDocument();
+    expect(screen.getByText(/Related System is required/i)).toBeInTheDocument();
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("creates a ticket and shows the official Ticket Number on success (UI-02)", async () => {
+    const createSpy = vi.spyOn(api, "createTicket").mockResolvedValue(TICKET);
+    const user = userEvent.setup();
+    render(<CreateTicket {...REQUIRE} />);
+
+    const comboboxes = await screen.findAllByRole("combobox");
+    // order: Category, Related System, Requested Priority
+    await user.selectOptions(comboboxes[0], "1");
+    await user.selectOptions(comboboxes[1], "1");
+    await user.type(screen.getByLabelText(/Summary/i), "Laptop battery drains quickly");
+    await user.type(screen.getByLabelText(/Description/i), "Battery drops fast.");
+    await user.click(screen.getByRole("button", { name: /Submit Ticket/i }));
+
+    expect(await screen.findByText(/TK-000001/i)).toBeInTheDocument();
+    expect(createSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ requesterId: 1, summary: "Laptop battery drains quickly" })
+    );
+  });
+
+  it("disables the submit button and shows a busy state while submitting (UI-04)", async () => {
+    let resolveFn!: (t: api.Ticket) => void;
+    vi.spyOn(api, "createTicket").mockReturnValue(
+      new Promise((resolve) => {
+        resolveFn = resolve;
+      })
+    );
+    const user = userEvent.setup();
+    render(<CreateTicket {...REQUIRE} />);
+
+    const comboboxes = await screen.findAllByRole("combobox");
+    await user.selectOptions(comboboxes[0], "1");
+    await user.selectOptions(comboboxes[1], "1");
+    await user.type(screen.getByLabelText(/Summary/i), "Test ticket");
+    await user.type(screen.getByLabelText(/Description/i), "Details here.");
+    await user.click(screen.getByRole("button", { name: /Submit Ticket/i }));
+
+    expect(screen.getByRole("button", { name: /Submitting/i })).toBeDisabled();
+    resolveFn(TICKET);
+  });
+
+  it("shows a safe error state and preserves entered values on API failure (UI-03)", async () => {
+    const err = new Error("boom") as Error & { fields?: Record<string, string> };
+    err.fields = {};
+    vi.spyOn(api, "createTicket").mockRejectedValue(err);
+    const user = userEvent.setup();
+    render(<CreateTicket {...REQUIRE} />);
+
+    const comboboxes = await screen.findAllByRole("combobox");
+    await user.selectOptions(comboboxes[0], "1");
+    await user.selectOptions(comboboxes[1], "1");
+    await user.type(screen.getByLabelText(/Summary/i), "Kept after failure");
+    await user.type(screen.getByLabelText(/Description/i), "Still here.");
+    await user.click(screen.getByRole("button", { name: /Submit Ticket/i }));
+
+    expect(
+      await screen.findByText(/Your entered values were preserved/i)
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/Summary/i)).toHaveValue("Kept after failure");
+  });
+
+  it("shows server field errors from the response (invalid category etc.)", async () => {
+    const err = new Error("invalid") as Error & { fields?: Record<string, string> };
+    err.fields = { categoryId: "Category does not exist or is inactive." };
+    vi.spyOn(api, "createTicket").mockRejectedValue(err);
+    const user = userEvent.setup();
+    render(<CreateTicket {...REQUIRE} />);
+
+    const comboboxes = await screen.findAllByRole("combobox");
+    await user.selectOptions(comboboxes[0], "1");
+    await user.selectOptions(comboboxes[1], "1");
+    await user.type(screen.getByLabelText(/Summary/i), "A ticket");
+    await user.type(screen.getByLabelText(/Description/i), "Details.");
+    await user.click(screen.getByRole("button", { name: /Submit Ticket/i }));
+
+    expect(
+      await screen.findByText(/Category does not exist or is inactive/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -81,6 +81,13 @@ app.get("/api/development-requesters", async (_req: Request, res: Response) => {
 const VALID_PRIORITIES = ["LOW", "MEDIUM", "HIGH", "URGENT"] as const;
 
 app.post("/api/tickets", async (req: Request, res: Response) => {
+  const headerRequesterId = req.header("X-Requester-Id") ?? "";
+  if (headerRequesterId === "") {
+    return res
+      .status(403)
+      .json({ error: { code: "FORBIDDEN", message: "Missing X-Requester-Id header" } });
+  }
+
   const { requesterId, summary, description, categoryId, relatedSystemId, requestedPriority } =
     req.body ?? {};
 
@@ -111,6 +118,17 @@ app.post("/api/tickets", async (req: Request, res: Response) => {
 
   if (Object.keys(fields).length > 0) {
     return res.status(400).json({ error: { code: "VALIDATION_ERROR", message: "Invalid input.", fields } });
+  }
+
+  if (headerRequesterId !== String(requesterId)) {
+    return res
+      .status(403)
+      .json({
+        error: {
+          code: "FORBIDDEN", 
+          message: "X-Requester-Id does not match the requester in the request body.",
+        },
+      });
   }
 
   try {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,6 +1,7 @@
 import express, { Request, Response } from "express";
 import cors from "cors";
 import { getPrisma } from "./prisma.js";
+import { formatTicketNumber } from "./ticketNumber.js";
 // getPrisma() is your lazy database handle. Call it INSIDE a route when you
 // need the DB (Issue 4). It is intentionally unused until then.
 void getPrisma;
@@ -36,6 +37,24 @@ app.get("/api/categories", async (_req: Request, res: Response) => {
 });
 
 // ---------------------------------------------------------------------------
+// Issue 8 — Related Systems reference data for the Create Ticket form.
+// GET /api/related-systems -> only ACTIVE systems, in id order.
+// ---------------------------------------------------------------------------
+app.get("/api/related-systems", async (_req: Request, res: Response) => {
+  try {
+    const systems = await getPrisma().relatedSystem.findMany({
+      where: { active: true },
+      orderBy: { id: "asc" },
+    });
+    res.status(200).json({
+      items: systems.map(({ id, name, type }) => ({ id, name, type })),
+    });
+  } catch {
+    res.status(500).json({ error: "Unable to load related systems" });
+  }
+});
+
+// ---------------------------------------------------------------------------
 // Issue 7 — Development Requester context (testing-only "login")
 // GET /api/development-requesters -> only ACTIVE requesters, in id order.
 // The inactive requester must never appear in the selection dropdown.
@@ -51,6 +70,103 @@ app.get("/api/development-requesters", async (_req: Request, res: Response) => {
     });
   } catch {
     res.status(500).json({ error: "Unable to load development requesters" });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Issue 8 — Create a Ticket
+// POST /api/tickets -> validate input, persist, return 201 with the official
+// Ticket Number and backend-generated values (api-spec.md §4).
+// ---------------------------------------------------------------------------
+const VALID_PRIORITIES = ["LOW", "MEDIUM", "HIGH", "URGENT"] as const;
+
+app.post("/api/tickets", async (req: Request, res: Response) => {
+  const { requesterId, summary, description, categoryId, relatedSystemId, requestedPriority } =
+    req.body ?? {};
+
+  const fields: Record<string, string> = {};
+  const trimSummary = typeof summary === "string" ? summary.trim() : "";
+  const trimDescription = typeof description === "string" ? description.trim() : "";
+
+  if (!Number.isInteger(requesterId)) {
+    fields.requesterId = "A Development Requester is required.";
+  }
+  if (trimSummary === "") fields.summary = "Summary is required.";
+  if (trimDescription === "") fields.description = "Description is required.";
+  if (!Number.isInteger(categoryId)) {
+    fields.categoryId = "Category is required.";
+  }
+  if (!Number.isInteger(relatedSystemId)) {
+    fields.relatedSystemId = "Related System is required.";
+  }
+
+  let priority: (typeof VALID_PRIORITIES)[number] = "MEDIUM";
+  if (requestedPriority !== undefined && requestedPriority !== null && requestedPriority !== "") {
+    if (VALID_PRIORITIES.includes(requestedPriority)) {
+      priority = requestedPriority;
+    } else {
+      fields.requestedPriority = "Requested Priority is invalid.";
+    }
+  }
+
+  if (Object.keys(fields).length > 0) {
+    return res.status(400).json({ error: { code: "VALIDATION_ERROR", message: "Invalid input.", fields } });
+  }
+
+  try {
+    const prisma = getPrisma();
+
+    const requester = await prisma.developmentRequester.findUnique({
+      where: { id: requesterId },
+    });
+    const category = await prisma.category.findUnique({ where: { id: categoryId } });
+    const system = await prisma.relatedSystem.findUnique({ where: { id: relatedSystemId } });
+
+    if (!requester || !requester.active) {
+      return res.status(404).json({ error: { code: "NOT_FOUND", message: "Requester not found." } });
+    }
+    if (!category || !category.active) {
+      fields.categoryId = "Category does not exist or is inactive.";
+    }
+    if (!system || !system.active) {
+      fields.relatedSystemId = "Related System does not exist or is inactive.";
+    }
+    if (Object.keys(fields).length > 0) {
+      return res.status(400).json({ error: { code: "VALIDATION_ERROR", message: "Invalid input.", fields } });
+    }
+
+    const ticketCount = await prisma.ticket.count();
+    const ticket = await prisma.ticket.create({
+      data: {
+        ticketNumber: formatTicketNumber(ticketCount + 1),
+        summary: trimSummary,
+        description: trimDescription,
+        requesterId: requester.id,
+        categoryId: category!.id,
+        relatedSystemId: system!.id,
+        requestedPriority: priority,
+      },
+      include: { category: true, relatedSystem: true },
+    });
+
+    res.status(201).json({
+      ticket: {
+        ticketNumber: ticket.ticketNumber,
+        id: ticket.id,
+        summary: ticket.summary,
+        description: ticket.description,
+        requesterId: ticket.requesterId,
+        category: { id: ticket.category.id, name: ticket.category.name },
+        relatedSystem: { id: ticket.relatedSystem.id, name: ticket.relatedSystem.name },
+        requestedPriority: ticket.requestedPriority,
+        itPriority: ticket.itPriority,
+        currentStatus: ticket.currentStatus,
+        createdAt: ticket.createdAt,
+        updatedAt: ticket.updatedAt,
+      },
+    });
+  } catch {
+    res.status(500).json({ error: { code: "INTERNAL_ERROR", message: "Unable to create ticket" } });
   }
 });
 

--- a/server/src/ticketNumber.ts
+++ b/server/src/ticketNumber.ts
@@ -1,0 +1,4 @@
+// Official Ticket Number format (api-spec.md §4): "TK-<six-digit sequential>".
+export function formatTicketNumber(sequence: number): string {
+  return `TK-${String(sequence).padStart(6, "0")}`;
+}

--- a/server/tests/lab-02/create-ticket.api.test.ts
+++ b/server/tests/lab-02/create-ticket.api.test.ts
@@ -30,14 +30,17 @@ describe("POST /api/tickets", () => {
     expect(category).toBeTruthy();
     expect(system).toBeTruthy();
 
-    const res = await request(app).post("/api/tickets").send({
-      requesterId: alice!.id,
-      summary: "Laptop battery drains quickly",
-      description: "Battery drops from 100% to 20% in an hour.",
-      categoryId: category!.id,
-      relatedSystemId: system!.id,
-      requestedPriority: "MEDIUM",
-    });
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(alice!.id))
+      .send({
+        requesterId: alice!.id,
+        summary: "Laptop battery drains quickly",
+        description: "Battery drops from 100% to 20% in an hour.",
+        categoryId: category!.id,
+        relatedSystemId: system!.id,
+        requestedPriority: "MEDIUM",
+      });
 
     expect(res.status).toBe(201);
     expect(res.body.ticket.ticketNumber).toMatch(/^TK-\d{6}$/);
@@ -63,13 +66,16 @@ describe("POST /api/tickets", () => {
     const category = await prisma.category.findFirst();
     const system = await prisma.relatedSystem.findFirst();
 
-    const res = await request(app).post("/api/tickets").send({
-      requesterId: alice!.id,
-      summary: "",
-      description: "  ",
-      categoryId: category!.id,
-      relatedSystemId: system!.id,
-    });
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(alice!.id))
+      .send({
+        requesterId: alice!.id,
+        summary: "",
+        description: "  ",
+        categoryId: category!.id,
+        relatedSystemId: system!.id,
+      });
 
     expect(res.status).toBe(400);
     expect(res.body.error.fields.summary).toBeTruthy();
@@ -89,13 +95,16 @@ describe("POST /api/tickets", () => {
     const category = await prisma.category.findFirst();
     const system = await prisma.relatedSystem.findFirst();
 
-    const res = await request(app).post("/api/tickets").send({
-      requesterId: alice!.id,
-      summary: "Printer offline",
-      description: "The printer in room 202 is unreachable.",
-      categoryId: category!.id,
-      relatedSystemId: system!.id,
-    });
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(alice!.id))
+      .send({
+        requesterId: alice!.id,
+        summary: "Printer offline",
+        description: "The printer in room 202 is unreachable.",
+        categoryId: category!.id,
+        relatedSystemId: system!.id,
+      });
 
     expect(res.status).toBe(201);
     expect(res.body.ticket.requestedPriority).toBe("MEDIUM");
@@ -110,16 +119,75 @@ describe("POST /api/tickets", () => {
     });
     const system = await prisma.relatedSystem.findFirst();
 
-    const res = await request(app).post("/api/tickets").send({
-      requesterId: alice!.id,
-      summary: "Bad category",
-      description: "This ticket refers to a missing category.",
-      categoryId: 999999,
-      relatedSystemId: system!.id,
-    });
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(alice!.id))
+      .send({
+        requesterId: alice!.id,
+        summary: "Bad category",
+        description: "This ticket refers to a missing category.",
+        categoryId: 999999,
+        relatedSystemId: system!.id,
+      });
 
     expect(res.status).toBe(400);
     expect(res.body.error.fields.categoryId).toBeTruthy();
+
+    const after = await prisma.ticket.count();
+    expect(after).toBe(before);
+  });
+
+  it("rejects a missing X-Requester-Id header with 403", async () => {
+    const prisma = getPrisma();
+    const before = await prisma.ticket.count();
+
+    const alice = await prisma.developmentRequester.findFirst({
+      where: { email: "alice.anderson@example.com" },
+    });
+    const category = await prisma.category.findFirst();
+    const system = await prisma.relatedSystem.findFirst();
+
+    const res = await request(app).post("/api/tickets").send({
+      requesterId: alice!.id,
+      summary: "No header",
+      description: "This should not be created.",
+      categoryId: category!.id,
+      relatedSystemId: system!.id,
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+
+    const after = await prisma.ticket.count();
+    expect(after).toBe(before);
+  });
+
+  it("rejects an X-Requester-Id that does not match the request body with 403", async () => {
+    const prisma = getPrisma();
+    const before = await prisma.ticket.count();
+
+    const alice = await prisma.developmentRequester.findFirst({
+      where: { email: "alice.anderson@example.com" },
+    });
+    const other = await prisma.developmentRequester.findFirst({
+      where: { email: "bob.brown@example.com" },
+    });
+    const category = await prisma.category.findFirst();
+    const system = await prisma.relatedSystem.findFirst();
+
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(other!.id))
+      .send({
+        requesterId: alice!.id,
+        summary: "Spoofed header",
+        description: "Header must match the requester in the body.",
+        categoryId: category!.id,
+        relatedSystemId: system!.id,
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
 
     const after = await prisma.ticket.count();
     expect(after).toBe(before);

--- a/server/tests/lab-02/create-ticket.api.test.ts
+++ b/server/tests/lab-02/create-ticket.api.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, afterAll } from "vitest";
+import request from "supertest";
+import { getPrisma } from "../../src/prisma.js";
+import { app } from "../../src/app.js";
+import {
+  seedRequesters,
+  seedCategories,
+  seedRelatedSystems,
+} from "../../prisma/seed.js";
+
+describe("POST /api/tickets", () => {
+  afterAll(async () => {
+    const prisma = getPrisma();
+    await prisma.ticket.deleteMany();
+    await seedCategories(prisma);
+    await seedRelatedSystems(prisma);
+    await seedRequesters(prisma);
+  });
+
+  it("creates a valid ticket and returns 201 with an official Ticket Number (API-01)", async () => {
+    const prisma = getPrisma();
+    await prisma.ticket.deleteMany();
+
+    const alice = await prisma.developmentRequester.findFirst({
+      where: { email: "alice.anderson@example.com" },
+    });
+    const category = await prisma.category.findFirst({ where: { name: "Hardware" } });
+    const system = await prisma.relatedSystem.findFirst({ where: { name: "ERP System" } });
+    expect(alice).toBeTruthy();
+    expect(category).toBeTruthy();
+    expect(system).toBeTruthy();
+
+    const res = await request(app).post("/api/tickets").send({
+      requesterId: alice!.id,
+      summary: "Laptop battery drains quickly",
+      description: "Battery drops from 100% to 20% in an hour.",
+      categoryId: category!.id,
+      relatedSystemId: system!.id,
+      requestedPriority: "MEDIUM",
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.ticket.ticketNumber).toMatch(/^TK-\d{6}$/);
+    expect(res.body.ticket.summary).toBe("Laptop battery drains quickly");
+    expect(res.body.ticket.requesterId).toBe(alice!.id);
+    expect(res.body.ticket.currentStatus).toBe("SUBMITTED");
+    expect(res.body.ticket.category.name).toBe("Hardware");
+    expect(res.body.ticket.relatedSystem.name).toBe("ERP System");
+
+    const saved = await prisma.ticket.findUnique({
+      where: { ticketNumber: res.body.ticket.ticketNumber },
+    });
+    expect(saved).toBeTruthy();
+  });
+
+  it("rejects a missing summary with field errors and no save (API-02)", async () => {
+    const prisma = getPrisma();
+    const before = await prisma.ticket.count();
+
+    const alice = await prisma.developmentRequester.findFirst({
+      where: { email: "alice.anderson@example.com" },
+    });
+    const category = await prisma.category.findFirst();
+    const system = await prisma.relatedSystem.findFirst();
+
+    const res = await request(app).post("/api/tickets").send({
+      requesterId: alice!.id,
+      summary: "",
+      description: "  ",
+      categoryId: category!.id,
+      relatedSystemId: system!.id,
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.fields.summary).toBeTruthy();
+    expect(res.body.error.fields.description).toBeTruthy();
+
+    const after = await prisma.ticket.count();
+    expect(after).toBe(before);
+  });
+
+  it("defaults requestedPriority to MEDIUM when omitted (BR-06)", async () => {
+    const prisma = getPrisma();
+    await prisma.ticket.deleteMany();
+
+    const alice = await prisma.developmentRequester.findFirst({
+      where: { email: "alice.anderson@example.com" },
+    });
+    const category = await prisma.category.findFirst();
+    const system = await prisma.relatedSystem.findFirst();
+
+    const res = await request(app).post("/api/tickets").send({
+      requesterId: alice!.id,
+      summary: "Printer offline",
+      description: "The printer in room 202 is unreachable.",
+      categoryId: category!.id,
+      relatedSystemId: system!.id,
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.ticket.requestedPriority).toBe("MEDIUM");
+  });
+
+  it("rejects a categoryId that does not reference an active category", async () => {
+    const prisma = getPrisma();
+    const before = await prisma.ticket.count();
+
+    const alice = await prisma.developmentRequester.findFirst({
+      where: { email: "alice.anderson@example.com" },
+    });
+    const system = await prisma.relatedSystem.findFirst();
+
+    const res = await request(app).post("/api/tickets").send({
+      requesterId: alice!.id,
+      summary: "Bad category",
+      description: "This ticket refers to a missing category.",
+      categoryId: 999999,
+      relatedSystemId: system!.id,
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.fields.categoryId).toBeTruthy();
+
+    const after = await prisma.ticket.count();
+    expect(after).toBe(before);
+  });
+});

--- a/server/tests/lab-02/ticket-number.test.ts
+++ b/server/tests/lab-02/ticket-number.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { formatTicketNumber } from "../../src/ticketNumber.js";
+
+describe("Ticket Number generator (UNIT-01)", () => {
+  it("formats a number as TK- followed by six padded digits", () => {
+    expect(formatTicketNumber(42)).toBe("TK-000042");
+  });
+
+  it("supports numbers beyond six digits", () => {
+    expect(formatTicketNumber(1234567)).toBe("TK-1234567");
+  });
+
+  it("starts at TK-000001", () => {
+    expect(formatTicketNumber(1)).toBe("TK-000001");
+  });
+});

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -4,5 +4,8 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["tests/**/*.test.ts"],
+    // All server tests share the same PostgreSQL database. Running test files
+    // sequentially avoids cross-file race conditions on shared seed data.
+    fileParallelism: false,
   },
 });


### PR DESCRIPTION
Addresses #16 (Issue 8: Ticket Creation).

## Backend
- `POST /api/tickets` (api-spec.md §4): validates summary/description (required, trimmed), categoryId/relatedSystemId (must reference active records), requestedPriority (valid enum, defaults to MEDIUM per BR-06). Returns 201 with the official Ticket Number `TK-XXXXXX` + backend-generated values.
- `GET /api/related-systems` reference endpoint (active only).
- `server/src/ticketNumber.ts`: exported `formatTicketNumber` generator (tk format, UNIT-01).

## Frontend
- **Create Ticket screen** (ui-spec.md §9):
  - system-generated read-only rows (Ticket Number, Status) styled distinctly via `.readonly-field`
  - requester shown read-only from the selection context
  - classification fields (Category, Related System, Requested Priority) grouped
  - Summary/Description with ample space + field-level validation messages below fields
  - primary Submit button with busy/disabled state while submitting
  - success state shows the official Ticket Number; failure preserves entered values and shows safe errors (including server field errors)
- Zen Green shell header (#006B3C / #0B7A46) + `styles.css` with ui-spec tokens.

## Tests (TDD)
- server `create-ticket.api.test.ts` (valid create/201+ticketNumber, missing fields→400, default priority, invalid category) + `ticket-number.test.ts` (3 unit)
- client `CreateTicket.test.tsx` (invalid submit no API call, success shows ticket number, busy state, failure preserves values, server field errors)
- `vitest.config.ts` now runs server test files sequentially (`fileParallelism: false`) to avoid cross-file DB races.

## Verification
- `cd server && npm test` → **22/22 passing**
- `cd client && npm test` → **14/14 passing**
- `tsc --noEmit` clean on both sides.

**Not merged — awaiting peer review.**