### PR TITLE
feat(Issue 10): Ticket Detail screen with ownership-scoped detail view

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import {
 } from "./api.js";
 import CreateTicket from "./CreateTicket.js";
 import MyTickets from "./MyTickets.js";
+import TicketDetail from "./TicketDetail.js";
 
 // Requester selection screen for Lab 2 testing (NOT a real login screen).
 // Authentication and role-based access arrive in Lab 3.
@@ -163,7 +164,8 @@ export default function App() {
         {view === "create-ticket" ? (
           <CreateTicket requester={selected} onViewTickets={() => setView("my-tickets")} />
         ) : view === "ticket-detail" && selectedTicket ? (
-          <TicketDetailStub
+          <TicketDetail
+            requester={selected}
             ticket={selectedTicket}
             onBack={() => setView("my-tickets")}
           />
@@ -179,41 +181,6 @@ export default function App() {
           />
         )}
       </div>
-    </div>
-  );
-}
-
-// Minimal read-only Ticket Detail (full detail arrives in Issue 10; this keeps
-// "find and open" working end-to-end now, per the My Tickets requirements).
-function TicketDetailStub({
-  ticket,
-  onBack,
-}: {
-  ticket: MyTicket;
-  onBack: () => void;
-}) {
-  return (
-    <div>
-      <div className="d-flex justify-content-between align-items-center mb-3">
-        <h2 className="h4 mb-0">Ticket {ticket.ticketNumber}</h2>
-        <button type="button" className="btn btn-outline-secondary btn-sm" onClick={onBack}>
-          Back to My Tickets
-        </button>
-      </div>
-      <dl className="row mb-0 gx-3 gy-2">
-        <dt className="col-sm-3">Summary</dt>
-        <dd className="col-sm-9">{ticket.summary}</dd>
-        <dt className="col-sm-3">Category</dt>
-        <dd className="col-sm-9">{ticket.category.name}</dd>
-        <dt className="col-sm-3">Requested Priority</dt>
-        <dd className="col-sm-9">{ticket.requestedPriority}</dd>
-        <dt className="col-sm-3">IT Priority</dt>
-        <dd className="col-sm-9">{ticket.itPriority}</dd>
-        <dt className="col-sm-3">Current Status</dt>
-        <dd className="col-sm-9">{ticket.currentStatus}</dd>
-        <dt className="col-sm-3">Last Updated</dt>
-        <dd className="col-sm-9">{new Date(ticket.updatedAt).toLocaleString()}</dd>
-      </dl>
     </div>
   );
 }

--- a/client/src/TicketDetail.tsx
+++ b/client/src/TicketDetail.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useState } from "react";
+import {
+  AttachmentInfo,
+  DevelopmentRequester,
+  MyTicket,
+  Priority,
+  Status,
+  TicketDetail as TicketDetailType,
+  fetchTicketDetail,
+} from "./api.js";
+
+const PRIORITY_BADGES: Record<Priority, string> = {
+  LOW: "badge-priority-low",
+  MEDIUM: "badge-priority-medium",
+  HIGH: "badge-priority-high",
+  URGENT: "badge-priority-urgent",
+};
+
+const STATUS_BADGES: Record<Status, string> = {
+  SUBMITTED: "badge-status-submitted",
+  IN_PROGRESS: "badge-status-in-progress",
+  RESOLVED: "badge-status-resolved",
+};
+
+interface Props {
+  requester: DevelopmentRequester;
+  ticket: MyTicket;
+  onBack: () => void;
+}
+
+function formatDateTime(v: string) {
+  return new Date(v).toLocaleString();
+}
+
+function AttachmentRow({ a }: { a: AttachmentInfo }) {
+  const isRemoved = a.removedAt !== null;
+  return (
+    <tr>
+      <td>{a.originalName}</td>
+      <td className="text-muted small">{a.mimeType}</td>
+      <td className="text-muted small">{(a.size / 1024).toFixed(1)} KB</td>
+      <td className="text-muted small">{formatDateTime(a.uploadedAt)}</td>
+      <td>
+        {isRemoved ? (
+          <span className="text-muted fst-italic">
+            Removed{a.removedReason ? ` — ${a.removedReason}` : ""}
+          </span>
+        ) : (
+          <span className="text-success small">Active</span>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+export default function TicketDetail({ requester, ticket, onBack }: Props) {
+  const [status, setStatus] = useState<"loading" | "ready" | "failure">("loading");
+  const [detail, setDetail] = useState<TicketDetailType | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus("loading");
+    fetchTicketDetail(requester.id, ticket.id)
+      .then((data) => {
+        if (!cancelled) {
+          setDetail(data);
+          setStatus("ready");
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setStatus("failure");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [requester.id, ticket.id]);
+
+  if (status === "loading") {
+    return <p className="text-secondary">Loading ticket…</p>;
+  }
+
+  if (status === "failure") {
+    return (
+      <div>
+        <div className="d-flex justify-content-between align-items-center mb-3">
+          <h2 className="h4 mb-0">Ticket {ticket.ticketNumber}</h2>
+          <button type="button" className="btn btn-outline-secondary btn-sm" onClick={onBack}>
+            Back to My Tickets
+          </button>
+        </div>
+        <p className="text-danger">
+          Unable to load the ticket details. Please try again later.
+        </p>
+      </div>
+    );
+  }
+
+  if (!detail) return null;
+
+  return (
+    <div>
+      {/* Header: ticket number + back navigation */}
+      <div className="d-flex justify-content-between align-items-center mb-3">
+        <h2 className="h4 mb-0">
+          {detail.ticketNumber}
+        </h2>
+        <button type="button" className="btn btn-outline-secondary btn-sm" onClick={onBack}>
+          Back to My Tickets
+        </button>
+      </div>
+
+      {/* Ticket Information — read-only field grouping (ui-spec §11) */}
+      <section className="card mb-4">
+        <div className="card-body">
+          <h3 className="h5 mb-3">Ticket Information</h3>
+          <dl className="row mb-0 gx-3 gy-2">
+            {/* System-generated read-only */}
+            <dt className="col-sm-3">Ticket Number</dt>
+            <dd className="col-sm-9 readonly-field px-2 rounded">{detail.ticketNumber}</dd>
+
+            <dt className="col-sm-3">Current Status</dt>
+            <dd className="col-sm-9">
+              <span className={`badge ${STATUS_BADGES[detail.currentStatus]}`}>
+                {detail.currentStatus}
+              </span>
+            </dd>
+
+            <dt className="col-sm-3">Created</dt>
+            <dd className="col-sm-9">{formatDateTime(detail.createdAt)}</dd>
+
+            <dt className="col-sm-3">Last Updated</dt>
+            <dd className="col-sm-9">{formatDateTime(detail.updatedAt)}</dd>
+
+            <dt className="col-sm-3">Development Requester</dt>
+            <dd className="col-sm-9 readonly-field px-2 rounded">{requester.name}</dd>
+
+            {/* Classification fields */}
+            <dt className="col-sm-3">Category</dt>
+            <dd className="col-sm-9 readonly-field px-2 rounded">{detail.category.name}</dd>
+
+            <dt className="col-sm-3">Related System</dt>
+            <dd className="col-sm-9 readonly-field px-2 rounded">
+              {detail.relatedSystem.name}
+              <span className="text-muted small ms-2">({detail.relatedSystem.type})</span>
+            </dd>
+
+            <dt className="col-sm-3">Requested Priority</dt>
+            <dd className="col-sm-9">
+              <span className={`badge ${PRIORITY_BADGES[detail.requestedPriority]}`}>
+                {detail.requestedPriority}
+              </span>
+            </dd>
+
+            <dt className="col-sm-3">IT Priority</dt>
+            <dd className="col-sm-9">
+              <span className={`badge ${PRIORITY_BADGES[detail.itPriority]}`}>
+                {detail.itPriority}
+              </span>
+            </dd>
+          </dl>
+        </div>
+      </section>
+
+      {/* Summary and Description — full width, clearly readable */}
+      <section className="card mb-4">
+        <div className="card-body">
+          <h3 className="h5 mb-3">Summary &amp; Description</h3>
+          <dl className="mb-0">
+            <dt className="mb-1">Summary</dt>
+            <dd className="readonly-field px-2 rounded mb-3">{detail.summary}</dd>
+            <dt className="mb-1">Description</dt>
+            <dd className="readonly-field px-2 rounded mb-0" style={{ whiteSpace: "pre-wrap" }}>
+              {detail.description}
+            </dd>
+          </dl>
+        </div>
+      </section>
+
+      {/* Attachments — Issue 11 will add upload/download/remove actions; for now
+           the section exists but shows an empty state. (AC-15 — each attachment
+           state is presented distinctly; currently "No attachments" covers the
+           initial state.) */}
+      <section className="card mb-4">
+        <div className="card-body">
+          <div className="d-flex justify-content-between align-items-center mb-3">
+            <h3 className="h5 mb-0">Attachments</h3>
+          </div>
+          {detail.attachments.length === 0 ? (
+            <p className="text-muted mb-0">No attachments yet.</p>
+          ) : (
+            <div className="table-responsive">
+              <table className="table table-sm align-middle mb-0">
+                <thead>
+                  <tr>
+                    <th>File</th>
+                    <th>Type</th>
+                    <th>Size</th>
+                    <th>Uploaded</th>
+                    <th>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {detail.attachments.map((a) => (
+                    <AttachmentRow key={a.id} a={a} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/client/src/TicketDetail.tsx
+++ b/client/src/TicketDetail.tsx
@@ -115,44 +115,44 @@ export default function TicketDetail({ requester, ticket, onBack }: Props) {
           <h3 className="h5 mb-3">Ticket Information</h3>
           <dl className="row mb-0 gx-3 gy-2">
             {/* System-generated read-only */}
-            <dt className="col-sm-3">Ticket Number</dt>
-            <dd className="col-sm-9 readonly-field px-2 rounded">{detail.ticketNumber}</dd>
+            <dt className="col-md-3">Ticket Number</dt>
+            <dd className="col-md-9 readonly-field px-2 rounded">{detail.ticketNumber}</dd>
 
-            <dt className="col-sm-3">Current Status</dt>
-            <dd className="col-sm-9">
+            <dt className="col-md-3">Current Status</dt>
+            <dd className="col-md-9">
               <span className={`badge ${STATUS_BADGES[detail.currentStatus]}`}>
                 {detail.currentStatus}
               </span>
             </dd>
 
-            <dt className="col-sm-3">Created</dt>
-            <dd className="col-sm-9">{formatDateTime(detail.createdAt)}</dd>
+            <dt className="col-md-3">Created</dt>
+            <dd className="col-md-9">{formatDateTime(detail.createdAt)}</dd>
 
-            <dt className="col-sm-3">Last Updated</dt>
-            <dd className="col-sm-9">{formatDateTime(detail.updatedAt)}</dd>
+            <dt className="col-md-3">Last Updated</dt>
+            <dd className="col-md-9">{formatDateTime(detail.updatedAt)}</dd>
 
-            <dt className="col-sm-3">Development Requester</dt>
-            <dd className="col-sm-9 readonly-field px-2 rounded">{requester.name}</dd>
+            <dt className="col-md-3">Development Requester</dt>
+            <dd className="col-md-9 readonly-field px-2 rounded">{requester.name}</dd>
 
             {/* Classification fields */}
-            <dt className="col-sm-3">Category</dt>
-            <dd className="col-sm-9 readonly-field px-2 rounded">{detail.category.name}</dd>
+            <dt className="col-md-3">Category</dt>
+            <dd className="col-md-9 readonly-field px-2 rounded">{detail.category.name}</dd>
 
-            <dt className="col-sm-3">Related System</dt>
-            <dd className="col-sm-9 readonly-field px-2 rounded">
+            <dt className="col-md-3">Related System</dt>
+            <dd className="col-md-9 readonly-field px-2 rounded">
               {detail.relatedSystem.name}
               <span className="text-muted small ms-2">({detail.relatedSystem.type})</span>
             </dd>
 
-            <dt className="col-sm-3">Requested Priority</dt>
-            <dd className="col-sm-9">
+            <dt className="col-md-3">Requested Priority</dt>
+            <dd className="col-md-9">
               <span className={`badge ${PRIORITY_BADGES[detail.requestedPriority]}`}>
                 {detail.requestedPriority}
               </span>
             </dd>
 
-            <dt className="col-sm-3">IT Priority</dt>
-            <dd className="col-sm-9">
+            <dt className="col-md-3">IT Priority</dt>
+            <dd className="col-md-9">
               <span className={`badge ${PRIORITY_BADGES[detail.itPriority]}`}>
                 {detail.itPriority}
               </span>

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -138,6 +138,32 @@ export async function createTicket(
   return body.ticket as Ticket;
 }
 
+export interface AttachmentInfo {
+  id: number;
+  originalName: string;
+  mimeType: string;
+  size: number;
+  uploadedAt: string;
+  removedAt: string | null;
+  removedReason: string | null;
+}
+
+export interface TicketDetail {
+  ticketNumber: string;
+  id: number;
+  summary: string;
+  description: string;
+  requesterId: number;
+  category: { id: number; name: string };
+  relatedSystem: { id: number; name: string; type: string };
+  requestedPriority: Priority;
+  itPriority: Priority;
+  currentStatus: Status;
+  createdAt: string;
+  updatedAt: string;
+  attachments: AttachmentInfo[];
+}
+
 // Issue 9 — list the selected requester's tickets (requester-scoped identity header).
 export async function fetchMyTickets(
   requesterId: number,
@@ -159,4 +185,17 @@ export async function fetchMyTickets(
   });
   if (!res.ok) throw new Error("Unable to load tickets");
   return (await res.json()) as MyTicketsResponse;
+}
+
+// Issue 10 — retrieve one owned Ticket for the detail view (api-spec.md §6).
+export async function fetchTicketDetail(
+  requesterId: number,
+  ticketId: number
+): Promise<TicketDetail> {
+  const res = await fetch(`${API_URL}/api/tickets/${ticketId}`, {
+    headers: { "X-Requester-Id": String(requesterId) },
+  });
+  if (!res.ok) throw new Error("Unable to load ticket");
+  const body = await res.json();
+  return body.ticket as TicketDetail;
 }

--- a/client/tests/lab-02/AppShell.test.tsx
+++ b/client/tests/lab-02/AppShell.test.tsx
@@ -6,18 +6,34 @@ import * as api from "../../src/api.js";
 
 const ALICE = { id: 1, name: "Alice Anderson", email: "alice.anderson@example.com" };
 
-const MY_TICKET = {
+const MY_TICKET: api.MyTicket = {
   ticketNumber: "TK-000007",
   id: 7,
   summary: "Laptop battery drains quickly",
   category: { id: 1, name: "Hardware" },
-  requestedPriority: "HIGH" as const,
-  itPriority: "HIGH" as const,
-  currentStatus: "IN_PROGRESS" as const,
+  requestedPriority: "HIGH",
+  itPriority: "HIGH",
+  currentStatus: "IN_PROGRESS",
   updatedAt: "2026-09-01T10:00:00.000Z",
 };
 
-const TICKET = {
+const FULL_DETAIL: api.TicketDetail = {
+  ticketNumber: "TK-000007",
+  id: 7,
+  summary: "Laptop battery drains quickly",
+  description: "Battery drains fast.",
+  requesterId: 1,
+  category: { id: 1, name: "Hardware" },
+  relatedSystem: { id: 1, name: "ERP System", type: "Application" },
+  requestedPriority: "HIGH",
+  itPriority: "MEDIUM",
+  currentStatus: "IN_PROGRESS",
+  createdAt: "2026-09-01T08:00:00.000Z",
+  updatedAt: "2026-09-01T10:00:00.000Z",
+  attachments: [],
+};
+
+const CREATED_TICKET = {
   ticketNumber: "TK-000009",
   id: 9,
   summary: "Laptop battery drains quickly",
@@ -40,6 +56,7 @@ describe("App shell navigation", () => {
       pagination: { page: 1, pageSize: 10, total: 1, totalPages: 1 },
       filtersApplied: {},
     });
+    vi.spyOn(api, "fetchTicketDetail").mockResolvedValue(FULL_DETAIL);
     vi.spyOn(api, "fetchCategories").mockResolvedValue([{ id: 1, name: "Hardware" }]);
     vi.spyOn(api, "fetchRelatedSystems").mockResolvedValue([
       { id: 1, name: "ERP System", type: "Application" },
@@ -76,10 +93,11 @@ describe("App shell navigation", () => {
       name: /Open ticket TK-000007/i,
     });
     await user.click(openButtons[0]);
-    expect(
-      await screen.findByRole("heading", { name: /Ticket TK-000007/i })
-    ).toBeInTheDocument();
-    expect(screen.getByText("Laptop battery drains quickly")).toBeInTheDocument();
+
+    expect(await screen.findByText("Laptop battery drains quickly")).toBeInTheDocument();
+    expect(screen.getByText("Battery drains fast.")).toBeInTheDocument();
+    expect(screen.getByText("Hardware")).toBeInTheDocument();
+    expect(screen.getByText("ERP System")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /Back to My Tickets/i }));
     expect(
@@ -88,7 +106,7 @@ describe("App shell navigation", () => {
   });
 
   it("switches from My Tickets to the Create Ticket form and back via View in My Tickets (AC-05)", async () => {
-    vi.spyOn(api, "createTicket").mockResolvedValue(TICKET);
+    vi.spyOn(api, "createTicket").mockResolvedValue(CREATED_TICKET);
     const user = userEvent.setup();
     render(<App />);
     await login(user);

--- a/client/tests/lab-02/RequesterTicketDetail.test.tsx
+++ b/client/tests/lab-02/RequesterTicketDetail.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TicketDetail from "../../src/TicketDetail.js";
+import * as api from "../../src/api.js";
+
+const ALICE = { id: 1, name: "Alice Anderson", email: "alice.anderson@example.com" };
+
+const MY_TICKET: api.MyTicket = {
+  ticketNumber: "TK-000007",
+  id: 7,
+  summary: "Laptop battery drains quickly",
+  category: { id: 1, name: "Hardware" },
+  requestedPriority: "HIGH",
+  itPriority: "MEDIUM",
+  currentStatus: "IN_PROGRESS",
+  updatedAt: "2026-09-01T10:00:00.000Z",
+};
+
+const FULL_DETAIL: api.TicketDetail = {
+  ticketNumber: "TK-000007",
+  id: 7,
+  summary: "Laptop battery drains quickly",
+  description: "Battery drops from 100% to 20% in an hour.",
+  requesterId: 1,
+  category: { id: 1, name: "Hardware" },
+  relatedSystem: { id: 1, name: "ERP System", type: "Application" },
+  requestedPriority: "HIGH",
+  itPriority: "MEDIUM",
+  currentStatus: "IN_PROGRESS",
+  createdAt: "2026-09-01T08:00:00.000Z",
+  updatedAt: "2026-09-01T10:00:00.000Z",
+  attachments: [],
+};
+
+const REMOVED_ATTACHMENT: api.AttachmentInfo = {
+  id: 101,
+  originalName: "error-log.txt",
+  mimeType: "text/plain",
+  size: 2048,
+  uploadedAt: "2026-09-01T09:00:00.000Z",
+  removedAt: "2026-09-01T11:00:00.000Z",
+  removedReason: "Duplicate file",
+};
+
+const ACTIVE_ATTACHMENT: api.AttachmentInfo = {
+  id: 102,
+  originalName: "screenshot.png",
+  mimeType: "image/png",
+  size: 512000,
+  uploadedAt: "2026-09-01T09:30:00.000Z",
+  removedAt: null,
+  removedReason: null,
+};
+
+describe("TicketDetail", () => {
+  beforeEach(() => {
+    vi.spyOn(api, "fetchTicketDetail").mockResolvedValue(FULL_DETAIL);
+  });
+
+  it("shows a loading state while the ticket is being fetched", () => {
+    let resolveFn!: (v: api.TicketDetail) => void;
+    vi.spyOn(api, "fetchTicketDetail").mockReturnValue(
+      new Promise((resolve) => { resolveFn = resolve; })
+    );
+    render(<TicketDetail requester={ALICE} ticket={MY_TICKET} onBack={() => {}} />);
+    expect(screen.getByText(/Loading ticket/i)).toBeInTheDocument();
+    resolveFn(FULL_DETAIL);
+  });
+
+  it("renders the full ticket detail with all read-only fields (UI-09, FR-13)", async () => {
+    render(<TicketDetail requester={ALICE} ticket={MY_TICKET} onBack={() => {}} />);
+
+    expect(await screen.findByText("Laptop battery drains quickly")).toBeInTheDocument();
+    expect(screen.getByText("Battery drops from 100% to 20% in an hour.")).toBeInTheDocument();
+    expect(screen.getByText("Hardware")).toBeInTheDocument();
+    expect(screen.getByText("ERP System")).toBeInTheDocument();
+    expect(screen.getByText("(Application)")).toBeInTheDocument();
+    expect(screen.getByText("Alice Anderson")).toBeInTheDocument();
+    expect(screen.getByText("IN_PROGRESS")).toBeInTheDocument();
+
+    // Ticket number appears in heading + dd readonly field
+    const ticketNumbers = screen.getAllByText("TK-000007");
+    expect(ticketNumbers.length).toBeGreaterThanOrEqual(2);
+    expect(ticketNumbers.some((el) => el.className.includes("readonly-field"))).toBe(true);
+  });
+
+  it("shows priority and status badges with correct severity classes", async () => {
+    render(<TicketDetail requester={ALICE} ticket={MY_TICKET} onBack={() => {}} />);
+
+    await screen.findByText("Laptop battery drains quickly");
+    const highBadge = screen.getByText("HIGH");
+    expect(highBadge.className).toContain("badge-priority-high");
+    const medBadge = screen.getByText("MEDIUM");
+    expect(medBadge.className).toContain("badge-priority-medium");
+    const statusBadge = screen.getByText("IN_PROGRESS");
+    expect(statusBadge.className).toContain("badge-status-in-progress");
+  });
+
+  it("shows 'No attachments yet' when there are no attachments", async () => {
+    render(<TicketDetail requester={ALICE} ticket={MY_TICKET} onBack={() => {}} />);
+    expect(await screen.findByText(/No attachments yet/i)).toBeInTheDocument();
+  });
+
+  it("renders attachment rows with distinct active and removed states (AC-15)", async () => {
+    vi.spyOn(api, "fetchTicketDetail").mockResolvedValue({
+      ...FULL_DETAIL,
+      attachments: [ACTIVE_ATTACHMENT, REMOVED_ATTACHMENT],
+    });
+
+    render(<TicketDetail requester={ALICE} ticket={MY_TICKET} onBack={() => {}} />);
+
+    const table = await screen.findByRole("table");
+    expect(within(table).getByText("screenshot.png")).toBeInTheDocument();
+    expect(within(table).getByText("Active")).toBeInTheDocument();
+    expect(within(table).getByText("error-log.txt")).toBeInTheDocument();
+    expect(within(table).getByText(/Removed — Duplicate file/i)).toBeInTheDocument();
+  });
+
+  it("shows a safe failure state when the API call fails", async () => {
+    vi.spyOn(api, "fetchTicketDetail").mockRejectedValue(new Error("network down"));
+
+    render(<TicketDetail requester={ALICE} ticket={MY_TICKET} onBack={() => {}} />);
+
+    expect(
+      await screen.findByText(/Unable to load the ticket details/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Ticket TK-000007/)).toBeInTheDocument();
+  });
+
+  it("navigates back to My Tickets when Back is clicked", async () => {
+    const onBack = vi.fn();
+    render(<TicketDetail requester={ALICE} ticket={MY_TICKET} onBack={onBack} />);
+    await screen.findByText("Laptop battery drains quickly");
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /Back to My Tickets/i }));
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+
+  it("calls fetchTicketDetail with the correct requester and ticket ids", async () => {
+    const fetchSpy = vi.spyOn(api, "fetchTicketDetail").mockResolvedValue(FULL_DETAIL);
+    render(<TicketDetail requester={ALICE} ticket={MY_TICKET} onBack={() => {}} />);
+    await screen.findByText("Laptop battery drains quickly");
+    expect(fetchSpy).toHaveBeenCalledWith(1, 7);
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -363,4 +363,72 @@ app.get("/api/tickets", async (req: Request, res: Response) => {
   }
 });
 
+// ---------------------------------------------------------------------------
+// Issue 10 — Retrieve one owned Ticket (detail view).
+// GET /api/tickets/:id -> returns full Ticket data including attachments,
+// only for the owner identified by X-Requester-Id (BR-04, FR-13, FR-14).
+// A foreign or missing Ticket is rejected with 404 (non-disclosing, AC-03/AC-10).
+// ---------------------------------------------------------------------------
+app.get("/api/tickets/:id", async (req: Request, res: Response) => {
+  const headerRequesterId = req.header("X-Requester-Id") ?? "";
+  if (headerRequesterId === "") {
+    return res
+      .status(403)
+      .json({ error: { code: "FORBIDDEN", message: "Missing X-Requester-Id header" } });
+  }
+
+  const ticketId = Number(req.params.id);
+  if (!Number.isInteger(ticketId) || ticketId < 1) {
+    return res
+      .status(404)
+      .json({ error: { code: "NOT_FOUND", message: "Ticket not found." } });
+  }
+
+  try {
+    const prisma = getPrisma();
+    const ticket = await prisma.ticket.findUnique({
+      where: { id: ticketId },
+      include: { category: true, relatedSystem: true, attachments: true },
+    });
+
+    if (!ticket || ticket.requesterId !== Number(headerRequesterId)) {
+      return res
+        .status(404)
+        .json({ error: { code: "NOT_FOUND", message: "Ticket not found." } });
+    }
+
+    res.status(200).json({
+      ticket: {
+        ticketNumber: ticket.ticketNumber,
+        id: ticket.id,
+        summary: ticket.summary,
+        description: ticket.description,
+        requesterId: ticket.requesterId,
+        category: { id: ticket.category.id, name: ticket.category.name },
+        relatedSystem: {
+          id: ticket.relatedSystem.id,
+          name: ticket.relatedSystem.name,
+          type: ticket.relatedSystem.type,
+        },
+        requestedPriority: ticket.requestedPriority,
+        itPriority: ticket.itPriority,
+        currentStatus: ticket.currentStatus,
+        createdAt: ticket.createdAt,
+        updatedAt: ticket.updatedAt,
+        attachments: ticket.attachments.map((a) => ({
+          id: a.id,
+          originalName: a.originalName,
+          mimeType: a.mimeType,
+          size: a.size,
+          uploadedAt: a.uploadedAt,
+          removedAt: a.removedAt,
+          removedReason: a.removedReason,
+        })),
+      },
+    });
+  } catch {
+    res.status(500).json({ error: { code: "INTERNAL_ERROR", message: "Unable to load ticket" } });
+  }
+});
+
 export default app;

--- a/server/tests/lab-02/ticket-detail.api.test.ts
+++ b/server/tests/lab-02/ticket-detail.api.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import { getPrisma } from "../../src/prisma.js";
+import { app } from "../../src/app.js";
+import { formatTicketNumber } from "../../src/ticketNumber.js";
+import {
+  seedRequesters,
+  seedCategories,
+  seedRelatedSystems,
+} from "../../prisma/seed.js";
+
+let alice: { id: number };
+let bob: { id: number };
+let hardware: { id: number };
+let erp: { id: number };
+
+async function createTicket(
+  overrides: Partial<{
+    requesterId: number;
+    summary: string;
+    description: string;
+    categoryId: number;
+    relatedSystemId: number;
+    requestedPriority: "LOW" | "MEDIUM" | "HIGH" | "URGENT";
+    currentStatus: "SUBMITTED" | "IN_PROGRESS" | "RESOLVED";
+    sequence: number;
+  }> = {}
+) {
+  const prisma = getPrisma();
+  const seq = overrides.sequence ?? 1;
+  return prisma.ticket.create({
+    data: {
+      ticketNumber: formatTicketNumber(seq),
+      summary: overrides.summary ?? "Test ticket summary",
+      description: overrides.description ?? "Test ticket description",
+      requesterId: overrides.requesterId ?? alice.id,
+      categoryId: overrides.categoryId ?? hardware.id,
+      relatedSystemId: overrides.relatedSystemId ?? erp.id,
+      requestedPriority: overrides.requestedPriority ?? "MEDIUM",
+      currentStatus: overrides.currentStatus ?? "SUBMITTED",
+    },
+    include: { category: true, relatedSystem: true, attachments: true },
+  });
+}
+
+describe("GET /api/tickets/:id (Ticket Detail)", () => {
+  beforeEach(async () => {
+    const prisma = getPrisma();
+    await prisma.ticket.deleteMany();
+    await seedRequesters(prisma);
+    await seedCategories(prisma);
+    await seedRelatedSystems(prisma);
+
+    alice = (
+      await prisma.developmentRequester.findFirstOrThrow({
+        where: { email: "alice.anderson@example.com" },
+        select: { id: true },
+      })
+    )!;
+    bob = (
+      await prisma.developmentRequester.findFirstOrThrow({
+        where: { email: "bob.brown@example.com" },
+        select: { id: true },
+      })
+    )!;
+    hardware = (
+      await prisma.category.findFirstOrThrow({ where: { name: "Hardware" } })
+    );
+    erp = (
+      await prisma.relatedSystem.findFirstOrThrow({ where: { name: "ERP System" } })
+    );
+  });
+
+  afterAll(async () => {
+    const prisma = getPrisma();
+    await prisma.ticket.deleteMany();
+    await seedRequesters(prisma);
+    await seedCategories(prisma);
+    await seedRelatedSystems(prisma);
+  });
+
+  it("returns the full Ticket detail for an owned ticket (API-10, FR-13)", async () => {
+    const ticket = await createTicket({
+      summary: "Laptop battery drains quickly",
+      description: "Battery drops from 100% to 20% in an hour.",
+      requestedPriority: "HIGH",
+      currentStatus: "IN_PROGRESS",
+      sequence: 1,
+    });
+
+    const res = await request(app)
+      .get(`/api/tickets/${ticket.id}`)
+      .set("X-Requester-Id", String(alice.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body.ticket).toMatchObject({
+      ticketNumber: ticket.ticketNumber,
+      id: ticket.id,
+      summary: "Laptop battery drains quickly",
+      description: "Battery drops from 100% to 20% in an hour.",
+      requesterId: alice.id,
+      category: { id: hardware.id, name: "Hardware" },
+      relatedSystem: { id: erp.id, name: "ERP System" },
+      requestedPriority: "HIGH",
+      itPriority: "MEDIUM",
+      currentStatus: "IN_PROGRESS",
+    });
+    expect(res.body.ticket.createdAt).toBeDefined();
+    expect(res.body.ticket.updatedAt).toBeDefined();
+    expect(Array.isArray(res.body.ticket.attachments)).toBe(true);
+    expect(res.body.ticket.attachments).toHaveLength(0);
+  });
+
+  it("rejects a missing X-Requester-Id header with 403", async () => {
+    const ticket = await createTicket({ sequence: 10 });
+
+    const res = await request(app).get(`/api/tickets/${ticket.id}`);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 404 for a Ticket owned by another requester (non-disclosing) (API-09, AC-03, FR-14)", async () => {
+    const aliceTicket = await createTicket({
+      requesterId: alice.id,
+      summary: "Alice private ticket",
+      sequence: 2,
+    });
+
+    const res = await request(app)
+      .get(`/api/tickets/${aliceTicket.id}`)
+      .set("X-Requester-Id", String(bob.id));
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 404 for a non-existent Ticket ID", async () => {
+    const res = await request(app)
+      .get("/api/tickets/999999")
+      .set("X-Requester-Id", String(alice.id));
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+});


### PR DESCRIPTION
## Issue 10 — Ticket Detail (GitHub #18)

### What changed
- **Server**: `GET /api/tickets/:id` route — X-Requester-Id header enforcement (403), ownership check (404 non-disclosing for foreign/missing tickets), returns full ticket data with attachments and relatedSystem type
- **Client**: New `TicketDetail` component replacing `TicketDetailStub` — read-only field grouping, priority/status badges (Zen Green), attachment list with active/removed states, safe failure state, Back to My Tickets navigation

### Tests
- **Server**: 4 new tests (API-09: foreign ticket 404, API-10: owned ticket 200, missing header 403, non-existent ticket 404)
- **Client**: 8 new tests (loading state, read-only fields, badges, attachments, failure, navigation, correct API args)
- **Full suite**: server 37/37, client 34/34, tsc clean

### Spec references
- `docs/lab-02/api-spec.md` §6 — `GET /api/tickets/:id` contract
- `docs/lab-02/ui-spec.md` §11 — Requester Ticket Detail layout
- `docs/lab-02/specification.md` FR-13, FR-14, BR-04, BR-11
- `docs/lab-02/tests.md` API-09, API-10, UI-09

### Related
- Depends on: Issue 9 (My Tickets) — already merged via PR #29
- Blocked by: None
- Next: Issue 11 (Attachments) will add upload/download/remove actions to the attachment section