### PR TITLE
feat(Issue 11): Attachment Lifecycle — upload, download, soft-remove

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ server/prisma/*.db
 
 # vite dev cache
 .vite/
+
+# attachment file storage (runtime only; DB stores metadata)
+server/uploads/

--- a/client/src/TicketDetail.tsx
+++ b/client/src/TicketDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   AttachmentInfo,
   DevelopmentRequester,
@@ -6,7 +6,10 @@ import {
   Priority,
   Status,
   TicketDetail as TicketDetailType,
+  downloadAttachment,
   fetchTicketDetail,
+  removeAttachment,
+  uploadAttachment,
 } from "./api.js";
 
 const PRIORITY_BADGES: Record<Priority, string> = {
@@ -32,24 +35,191 @@ function formatDateTime(v: string) {
   return new Date(v).toLocaleString();
 }
 
-function AttachmentRow({ a }: { a: AttachmentInfo }) {
-  const isRemoved = a.removedAt !== null;
+type UploadPhase = "idle" | "busy";
+
+function AttachmentSection({
+  requesterId,
+  ticketId,
+  attachments,
+  onUploaded,
+  onUpdated,
+}: {
+  requesterId: number;
+  ticketId: number;
+  attachments: AttachmentInfo[];
+  onUploaded: (a: AttachmentInfo) => void;
+  onUpdated: (a: AttachmentInfo) => void;
+}) {
+  const [uploadPhase, setUploadPhase] = useState<UploadPhase>("idle");
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [downloadingId, setDownloadingId] = useState<number | null>(null);
+  const [removingId, setRemovingId] = useState<number | null>(null);
+  const [removeError, setRemoveError] = useState<string | null>(null);
+  const [unavailableError, setUnavailableError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  async function handleUpload() {
+    if (!selectedFile) return;
+    setUploadPhase("busy");
+    setUploadError(null);
+    try {
+      const created = await uploadAttachment(requesterId, ticketId, selectedFile);
+      onUploaded(created);
+      setSelectedFile(null);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    } catch (e) {
+      const err = e as Error & { fields?: Record<string, string> };
+      setUploadError(err.fields?.file ?? err.message);
+    } finally {
+      setUploadPhase("idle");
+    }
+  }
+
+  async function handleDownload(a: AttachmentInfo) {
+    setDownloadingId(a.id);
+    setUnavailableError(null);
+    try {
+      const { blob, filename } = await downloadAttachment(requesterId, a);
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = filename;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      const err = e as Error & { code?: string };
+      if (err.code === "UNAVAILABLE") setUnavailableError(a.originalName);
+    } finally {
+      setDownloadingId(null);
+    }
+  }
+
+  async function handleRemove(a: AttachmentInfo) {
+    const reason = window.prompt(
+      `Provide a removal reason for "${a.originalName}":`,
+      ""
+    );
+    if (reason === null) return;
+    if (reason.trim() === "") {
+      setRemoveError("A removal reason is required.");
+      return;
+    }
+    setRemovingId(a.id);
+    setRemoveError(null);
+    try {
+      const updated = await removeAttachment(requesterId, a.id, reason.trim());
+      onUpdated(updated);
+    } catch (e) {
+      const err = e as Error & { fields?: Record<string, string> };
+      setRemoveError(err.fields?.removedReason ?? err.message);
+    } finally {
+      setRemovingId(null);
+    }
+  }
+
   return (
-    <tr>
-      <td>{a.originalName}</td>
-      <td className="text-muted small">{a.mimeType}</td>
-      <td className="text-muted small">{(a.size / 1024).toFixed(1)} KB</td>
-      <td className="text-muted small">{formatDateTime(a.uploadedAt)}</td>
-      <td>
-        {isRemoved ? (
-          <span className="text-muted fst-italic">
-            Removed{a.removedReason ? ` — ${a.removedReason}` : ""}
-          </span>
-        ) : (
-          <span className="text-success small">Active</span>
+    <section className="card mb-4">
+      <div className="card-body">
+        <div className="d-flex justify-content-between align-items-center mb-3">
+          <h3 className="h5 mb-0">Attachments</h3>
+        </div>
+
+        {/* Upload control — placed logically within Ticket Detail (ui-spec §6) */}
+        <div className="d-flex flex-column flex-md-row gap-2 align-items-md-center mb-3">
+          <input
+            ref={fileInputRef}
+            type="file"
+            data-testid="attachment-file-input"
+            onChange={(e) => setSelectedFile(e.target.files?.[0] ?? null)}
+          />
+          <button
+            type="button"
+            className="btn btn-tok-primary"
+            onClick={handleUpload}
+            disabled={!selectedFile || uploadPhase === "busy"}
+          >
+            {uploadPhase === "busy" ? "Uploading…" : "Upload Attachment"}
+          </button>
+        </div>
+        {uploadError && <p className="text-danger small">{uploadError}</p>}
+        {removeError && <p className="text-danger small">{removeError}</p>}
+        {unavailableError && (
+          <p className="text-warning small">
+            The file "{unavailableError}" is not available on the server.
+          </p>
         )}
-      </td>
-    </tr>
+
+        {attachments.length === 0 ? (
+          <p className="text-muted mb-0">No attachments yet.</p>
+        ) : (
+          <div className="table-responsive">
+            <table className="table table-sm align-middle mb-0">
+              <thead>
+                <tr>
+                  <th>File</th>
+                  <th>Type</th>
+                  <th>Size</th>
+                  <th>Uploaded</th>
+                  <th>Status</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {attachments.map((a) => {
+                  const isRemoved = a.removedAt !== null;
+                  const isDownloading = downloadingId === a.id;
+                  const isRemoving = removingId === a.id;
+                  return (
+                    <tr key={a.id}>
+                      <td>{a.originalName}</td>
+                      <td className="text-muted small">{a.mimeType}</td>
+                      <td className="text-muted small">{(a.size / 1024).toFixed(1)} KB</td>
+                      <td className="text-muted small">{formatDateTime(a.uploadedAt)}</td>
+                      <td>
+                        {isRemoved ? (
+                          <span className="text-muted fst-italic">
+                            Removed{a.removedReason ? ` — ${a.removedReason}` : ""}
+                          </span>
+                        ) : (
+                          <span className="text-success small">Active</span>
+                        )}
+                      </td>
+                      <td>
+                        {isRemoved ? (
+                          <span className="text-muted fst-italic small">Blocked</span>
+                        ) : (
+                          <div className="d-flex gap-2">
+                            <button
+                              type="button"
+                              className="btn btn-outline-secondary btn-sm"
+                              onClick={() => handleDownload(a)}
+                              disabled={isDownloading || isRemoving}
+                            >
+                              {isDownloading ? "Downloading…" : "Download"}
+                            </button>
+                            <button
+                              type="button"
+                              className="btn btn-outline-danger btn-sm"
+                              onClick={() => handleRemove(a)}
+                              disabled={isDownloading || isRemoving}
+                            >
+                              {isRemoving ? "Removing…" : "Remove"}
+                            </button>
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </section>
   );
 }
 
@@ -96,6 +266,18 @@ export default function TicketDetail({ requester, ticket, onBack }: Props) {
   }
 
   if (!detail) return null;
+
+  const handleUploaded = (a: AttachmentInfo) => {
+    setDetail((d) => (d ? { ...d, attachments: [a, ...d.attachments] } : d));
+  };
+
+  const handleUpdated = (a: AttachmentInfo) => {
+    setDetail((d) =>
+      d
+        ? { ...d, attachments: d.attachments.map((x) => (x.id === a.id ? a : x)) }
+        : d
+    );
+  };
 
   return (
     <div>
@@ -176,39 +358,14 @@ export default function TicketDetail({ requester, ticket, onBack }: Props) {
         </div>
       </section>
 
-      {/* Attachments — Issue 11 will add upload/download/remove actions; for now
-           the section exists but shows an empty state. (AC-15 — each attachment
-           state is presented distinctly; currently "No attachments" covers the
-           initial state.) */}
-      <section className="card mb-4">
-        <div className="card-body">
-          <div className="d-flex justify-content-between align-items-center mb-3">
-            <h3 className="h5 mb-0">Attachments</h3>
-          </div>
-          {detail.attachments.length === 0 ? (
-            <p className="text-muted mb-0">No attachments yet.</p>
-          ) : (
-            <div className="table-responsive">
-              <table className="table table-sm align-middle mb-0">
-                <thead>
-                  <tr>
-                    <th>File</th>
-                    <th>Type</th>
-                    <th>Size</th>
-                    <th>Uploaded</th>
-                    <th>Status</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {detail.attachments.map((a) => (
-                    <AttachmentRow key={a.id} a={a} />
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </div>
-      </section>
+      {/* Attachments — upload / download / soft-remove (FR-15..18, ui-spec §6) */}
+      <AttachmentSection
+        requesterId={requester.id}
+        ticketId={detail.id}
+        attachments={detail.attachments}
+        onUploaded={handleUploaded}
+        onUpdated={handleUpdated}
+      />
     </div>
   );
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -187,6 +187,17 @@ export async function fetchMyTickets(
   return (await res.json()) as MyTicketsResponse;
 }
 
+export interface AttachmentInfo {
+  id: number;
+  ticketId?: number;
+  originalName: string;
+  mimeType: string;
+  size: number;
+  uploadedAt: string;
+  removedAt: string | null;
+  removedReason: string | null;
+}
+
 // Issue 10 — retrieve one owned Ticket for the detail view (api-spec.md §6).
 export async function fetchTicketDetail(
   requesterId: number,
@@ -198,4 +209,93 @@ export async function fetchTicketDetail(
   if (!res.ok) throw new Error("Unable to load ticket");
   const body = await res.json();
   return body.ticket as TicketDetail;
+}
+
+// ---------------------------------------------------------------------------
+// Issue 11 — Attachment lifecycle (FR-15..FR-18).
+// Upload, list metadata, download (active only), and soft-remove with reason.
+// ---------------------------------------------------------------------------
+
+// Upload a file to an owned Ticket (multipart, field `file`).
+export async function uploadAttachment(
+  requesterId: number,
+  ticketId: number,
+  file: File
+): Promise<AttachmentInfo> {
+  const form = new FormData();
+  form.append("file", file);
+  const res = await fetch(`${API_URL}/api/tickets/${ticketId}/attachments`, {
+    method: "POST",
+    headers: { "X-Requester-Id": String(requesterId) },
+    body: form,
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const err = new Error("Unable to upload attachment") as Error & {
+      fields?: Record<string, string>;
+    };
+    if (body?.error?.fields) err.fields = body.error.fields;
+    throw err;
+  }
+  return body.attachment as AttachmentInfo;
+}
+
+// List metadata for an owned Ticket's attachments (removed are included).
+export async function fetchTicketAttachments(
+  requesterId: number,
+  ticketId: number
+): Promise<AttachmentInfo[]> {
+  const res = await fetch(`${API_URL}/api/tickets/${ticketId}/attachments`, {
+    headers: { "X-Requester-Id": String(requesterId) },
+  });
+  if (!res.ok) throw new Error("Unable to load attachments");
+  const body: { items: AttachmentInfo[] } = await res.json();
+  return body.items;
+}
+
+// Download an active attachment. Returns the file data + suggested filename.
+export async function downloadAttachment(
+  requesterId: number,
+  attachment: AttachmentInfo
+): Promise<{ blob: Blob; filename: string; mimeType: string }> {
+  const res = await fetch(`${API_URL}/api/attachments/${attachment.id}/download`, {
+    headers: { "X-Requester-Id": String(requesterId) },
+  });
+  if (!res.ok) {
+    const err = new Error("Unable to download attachment") as Error & {
+      code?: string;
+    };
+    if (res.status === 410) err.code = "UNAVAILABLE";
+    throw err;
+  }
+  return {
+    blob: await res.blob(),
+    filename: attachment.originalName,
+    mimeType: attachment.mimeType,
+  };
+}
+
+// Soft-remove an attachment with a reason (BR-08).
+export async function removeAttachment(
+  requesterId: number,
+  attachmentId: number,
+  removedReason: string
+): Promise<AttachmentInfo> {
+  const res = await fetch(`${API_URL}/api/attachments/${attachmentId}`, {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Requester-Id": String(requesterId),
+    },
+    body: JSON.stringify({ removedReason }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const err = new Error("Unable to remove attachment") as Error & {
+      fields?: Record<string, string>;
+    };
+    if (body?.error?.fields) err.fields = body.error.fields;
+    throw err;
+  }
+  return body.attachment as AttachmentInfo;
 }

--- a/client/tests/lab-02/AttachmentSection.test.tsx
+++ b/client/tests/lab-02/AttachmentSection.test.tsx
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, within, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TicketDetail from "../../src/TicketDetail.js";
+import * as api from "../../src/api.js";
+
+const ALICE = { id: 1, name: "Alice Anderson", email: "alice.anderson@example.com" };
+
+const MY_TICKET: api.MyTicket = {
+  ticketNumber: "TK-000007",
+  id: 7,
+  summary: "Laptop battery drains quickly",
+  category: { id: 1, name: "Hardware" },
+  requestedPriority: "HIGH",
+  itPriority: "MEDIUM",
+  currentStatus: "IN_PROGRESS",
+  updatedAt: "2026-09-01T10:00:00.000Z",
+};
+
+const BASE_DETAIL: api.TicketDetail = {
+  ticketNumber: "TK-000007",
+  id: 7,
+  summary: "Laptop battery drains quickly",
+  description: "Battery drops from 100% to 20% in an hour.",
+  requesterId: 1,
+  category: { id: 1, name: "Hardware" },
+  relatedSystem: { id: 1, name: "ERP System", type: "Application" },
+  requestedPriority: "HIGH",
+  itPriority: "MEDIUM",
+  currentStatus: "IN_PROGRESS",
+  createdAt: "2026-09-01T08:00:00.000Z",
+  updatedAt: "2026-09-01T10:00:00.000Z",
+  attachments: [],
+};
+
+const ACTIVE: api.AttachmentInfo = {
+  id: 102,
+  ticketId: 7,
+  originalName: "screenshot.png",
+  mimeType: "image/png",
+  size: 512000,
+  uploadedAt: "2026-09-01T09:30:00.000Z",
+  removedAt: null,
+  removedReason: null,
+};
+
+const REMOVED: api.AttachmentInfo = {
+  id: 101,
+  ticketId: 7,
+  originalName: "error-log.txt",
+  mimeType: "text/plain",
+  size: 2048,
+  uploadedAt: "2026-09-01T09:00:00.000Z",
+  removedAt: "2026-09-01T11:00:00.000Z",
+  removedReason: "Duplicate file",
+};
+
+function makeDetail(attachments: api.AttachmentInfo[]): api.TicketDetail {
+  return { ...BASE_DETAIL, attachments };
+}
+
+function makeFile(name: string, type: string, size = 1000) {
+  return new File([new ArrayBuffer(size)], name, { type });
+}
+
+describe("TicketDetail attachments — Issue 11 (UI-10, AC-11, AC-15)", () => {
+  beforeEach(() => {
+    vi.spyOn(api, "fetchTicketDetail").mockResolvedValue(BASE_DETAIL);
+  });
+
+  it("shows an upload control and 'No attachments yet' when empty (initial state)", async () => {
+    render(<TicketDetail requester={ALICE} ticket={MY_TICKET} onBack={() => {}} />);
+
+    expect(await screen.findByText(/No attachments yet/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Upload Attachment/i })).toBeInTheDocument();
+    expect(
+      screen.getByTestId("attachment-file-input")
+    ).toBeInTheDocument();
+  });
+
+  it("disables the upload button until a file is chosen", async () => {
+    render(<TicketDetail requester={ALICE} ticket={MY_TICKET} onBack={() => {}} />);
+    const uploadBtn = await screen.findByRole("button", { name: /Upload Attachment/i });
+    expect(uploadBtn).toBeDisabled();
+
+    const input = await screen.findByTestId("attachment-file-input");
+    fireEvent.change(input, { target: { files: [makeFile("a.txt", "text/plain")] } });
+    expect(uploadBtn).not.toBeDisabled();
+  });
+
+  it("uploads a file and appends it to the list (FR-15, AC-11)", async () => {
+    const created: api.AttachmentInfo = {
+      id: 300,
+      ticketId: 7,
+      originalName: "new.png",
+      mimeType: "image/png",
+      size: 1000,
+      uploadedAt: "2026-09-02T00:00:00.000Z",
+      removedAt: null,
+      removedReason: null,
+    };
+    const uploadSpy = vi.spyOn(api, "uploadAttachment").mockResolvedValue(created);
+
+    render(<TicketDetail requester={ALICE} ticket={MY_TICKET} onBack={() => {}} />);
+    const input = await screen.findByTestId("attachment-file-input");
+    fireEvent.change(input, { target: { files: [makeFile("new.png", "image/png")] } });
+
+    await userEvent.setup().click(screen.getByRole("button", { name: /Upload Attachment/i }));
+
+    expect(uploadSpy).toHaveBeenCalledWith(1, 7, expect.any(File));
+    expect(await screen.findByText("new.png")).toBeInTheDocument();
+  });
+
+  it("shows a field-level error when upload is rejected (BR-07, AC-11)", async () => {
+    vi.spyOn(api, "uploadAttachment").mockRejectedValue(
+      Object.assign(new Error("bad"), { fields: { file: "This file type is not supported." } })
+    );
+
+    render(<TicketDetail requester={ALICE} ticket={MY_TICKET} onBack={() => {}} />);
+    const input = await screen.findByTestId("attachment-file-input");
+    fireEvent.change(input, { target: { files: [makeFile("x.exe", "application/x-msdownload")] } });
+
+    await userEvent.setup().click(screen.getByRole("button", { name: /Upload Attachment/i }));
+
+    expect(await screen.findByText("This file type is not supported.")).toBeInTheDocument();
+  });
+
+  it("downloads an active attachment (FR-17, AC-08)", async () => {
+    vi.spyOn(api, "fetchTicketDetail").mockResolvedValue(makeDetail([ACTIVE]));
+    const downloadSpy = vi.spyOn(api, "downloadAttachment").mockResolvedValue({
+      blob: new Blob(["x"], { type: "image/png" }),
+      filename: "screenshot.png",
+      mimeType: "image/png",
+    });
+
+    render(<TicketDetail requester={ALICE} ticket={MY_TICKET} onBack={() => {}} />);
+
+    const downloadBtn = await screen.findByRole("button", { name: /Download/i });
+    await userEvent.setup().click(downloadBtn);
+
+    expect(downloadSpy).toHaveBeenCalledWith(1, ACTIVE);
+  });
+
+  it("shows unavailable state when download returns 410 (AC-15, unavailable)", async () => {
+    vi.spyOn(api, "fetchTicketDetail").mockResolvedValue(makeDetail([ACTIVE]));
+    vi.spyOn(api, "downloadAttachment").mockRejectedValue(
+      Object.assign(new Error("gone"), { code: "UNAVAILABLE" })
+    );
+
+    render(<TicketDetail requester={ALICE} ticket={MY_TICKET} onBack={() => {}} />);
+
+    const downloadBtn = await screen.findByRole("button", { name: /Download/i });
+    await userEvent.setup().click(downloadBtn);
+
+    expect(
+      await screen.findByText(/not available on the server/i)
+    ).toBeInTheDocument();
+  });
+
+  it("soft-removes an attachment with a reason and lists it as removed (FR-18, AC-09)", async () => {
+    vi.spyOn(api, "fetchTicketDetail").mockResolvedValue(makeDetail([ACTIVE]));
+    const updated: api.AttachmentInfo = {
+      ...ACTIVE,
+      removedAt: "2026-09-02T01:00:00.000Z",
+      removedReason: "Uploaded the wrong file",
+    };
+    const removeSpy = vi.spyOn(api, "removeAttachment").mockResolvedValue(updated);
+    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("Uploaded the wrong file");
+
+    render(<TicketDetail requester={ALICE} ticket={MY_TICKET} onBack={() => {}} />);
+
+    const removeBtn = await screen.findByRole("button", { name: /Remove/i });
+    await userEvent.setup().click(removeBtn);
+
+    expect(removeSpy).toHaveBeenCalledWith(1, ACTIVE.id, "Uploaded the wrong file");
+    expect(promptSpy).toHaveBeenCalled();
+    expect(await screen.findByText(/Removed — Uploaded the wrong file/i)).toBeInTheDocument();
+  });
+
+  it("blocks download/remove actions for a removed attachment (BR-09, AC-09)", async () => {
+    vi.spyOn(api, "fetchTicketDetail").mockResolvedValue(makeDetail([REMOVED]));
+
+    render(<TicketDetail requester={ALICE} ticket={MY_TICKET} onBack={() => {}} />);
+
+    expect(await screen.findByText(/error-log.txt/)).toBeInTheDocument();
+    expect(screen.getByText("Blocked")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Download/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Remove/i })).not.toBeInTheDocument();
+  });
+
+  it("shows removed metadata with reason for a removed attachment (BR-09)", async () => {
+    vi.spyOn(api, "fetchTicketDetail").mockResolvedValue(makeDetail([REMOVED]));
+
+    render(<TicketDetail requester={ALICE} ticket={MY_TICKET} onBack={() => {}} />);
+
+    expect(await screen.findByText(/Removed — Duplicate file/i)).toBeInTheDocument();
+  });
+});

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,11 +10,13 @@
       "dependencies": {
         "@prisma/client": "^5.22.0",
         "cors": "^2.8.5",
-        "express": "^4.21.2"
+        "express": "^4.21.2",
+        "multer": "^2.3.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
+        "@types/multer": "^2.2.0",
         "@types/node": "^22.10.2",
         "@types/supertest": "^6.0.2",
         "prisma": "^5.22.0",
@@ -1065,6 +1067,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-3U1troeqGV8Ntp7Q3klwf4zr23VEoqYVocYXaswm9+8z3O9UHDYAqLxjJ/h550iRADTjKdOdhhasXw6gD6kYtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
@@ -1272,6 +1284,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1324,6 +1342,23 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -1422,6 +1457,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -2077,6 +2127,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.3.0.tgz",
+      "integrity": "sha512-cjNbm3sttszgZeGfJR124D+jFEfkXCVAsoPBmFn9X7UxmDSFHWqE2CoEj0vrmSpuAFnqWR1Szcm9QTsiHr60Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
@@ -2287,6 +2356,20 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/rollup": {
@@ -2524,6 +2607,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -2693,6 +2793,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2722,6 +2828,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -11,15 +11,19 @@
     "prisma:seed": "tsx prisma/seed.ts",
     "test": "vitest run"
   },
-  "prisma": { "seed": "tsx prisma/seed.ts" },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
+  },
   "dependencies": {
     "@prisma/client": "^5.22.0",
     "cors": "^2.8.5",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "multer": "^2.3.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/multer": "^2.2.0",
     "@types/node": "^22.10.2",
     "@types/supertest": "^6.0.2",
     "prisma": "^5.22.0",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,5 +1,9 @@
+import path from "node:path";
+import fs from "node:fs/promises";
+import crypto from "node:crypto";
 import express, { Request, Response } from "express";
 import cors from "cors";
+import multer from "multer";
 import type { Prisma } from "@prisma/client";
 import { getPrisma } from "./prisma.js";
 import { formatTicketNumber } from "./ticketNumber.js";
@@ -13,6 +17,36 @@ export const app = express();
 
 app.use(cors());          // already wired: lets the Vite dev server call this API
 app.use(express.json());
+
+// ---------------------------------------------------------------------------
+// Issue 11 — Attachment upload configuration (BR-07).
+// Files are stored on the local filesystem under the configured upload
+// directory; the database stores metadata + a generated stored filename.
+// ---------------------------------------------------------------------------
+export const MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024; // 10 MB
+const ALLOWED_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "application/pdf",
+  "text/plain",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/msword",
+  "application/vnd.ms-excel",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/zip",
+]);
+
+export function resolveUploadDir(): string {
+  return process.env.UPLOAD_DIR
+    ? path.resolve(process.env.UPLOAD_DIR)
+    : path.resolve(process.cwd(), "uploads");
+}
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_ATTACHMENT_SIZE },
+});
 
 // ---------------------------------------------------------------------------
 // Issue 2 — API health check
@@ -431,4 +465,260 @@ app.get("/api/tickets/:id", async (req: Request, res: Response) => {
   }
 });
 
-export default app;
+// ---------------------------------------------------------------------------
+// Issue 11 — Attachment lifecycle (FR-15..FR-18, BR-07..BR-09).
+// Upload, list metadata, download (active only), and soft-remove with reason.
+// All endpoints enforce ownership (BR-04) and reject foreign resources with a
+// non-disclosing 404 (AC-10).
+// ---------------------------------------------------------------------------
+
+function requesterIdFrom(req: Request): number | null {
+  const raw = req.header("X-Requester-Id") ?? "";
+  if (raw === "") return null;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+function attachNotFound(res: Response) {
+  return res.status(404).json({ error: { code: "NOT_FOUND", message: "Not found." } });
+}
+
+// Helper: resolve the ticket owner; returns null if the ticket is missing or
+// not owned by the requester (so we can respond with a non-disclosing 404).
+async function resolveOwnedTicket(requesterId: number, ticketId: number) {
+  const prisma = getPrisma();
+  const ticket = await prisma.ticket.findUnique({
+    where: { id: ticketId },
+    select: { id: true, requesterId: true },
+  });
+  if (!ticket || ticket.requesterId !== requesterId) return null;
+  return ticket;
+}
+
+// POST /api/tickets/:id/attachments — upload (FR-15, BR-07)
+app.post(
+  "/api/tickets/:id/attachments",
+  upload.single("file"),
+  async (req: Request, res: Response) => {
+    const requesterId = requesterIdFrom(req);
+    if (requesterId === null) {
+      return res
+        .status(403)
+        .json({ error: { code: "FORBIDDEN", message: "Missing X-Requester-Id header" } });
+    }
+
+    const ticketId = Number(req.params.id);
+    try {
+      const owned = await resolveOwnedTicket(requesterId, ticketId);
+      if (!owned) return attachNotFound(res);
+
+      const file = req.file;
+      if (!file) {
+        return res.status(400).json({
+          error: { code: "INVALID_FILE", message: "No file was provided", fields: { file: "Please choose a file to upload." } },
+        });
+      }
+
+      if (!ALLOWED_MIME_TYPES.has(file.mimetype)) {
+        return res.status(400).json({
+          error: { code: "INVALID_FILE", message: "File type is not supported", fields: { file: "This file type is not supported." } },
+        });
+      }
+
+      const safeOriginal = path.basename(file.originalname);
+      const storedName =
+        crypto.randomUUID() + path.extname(safeOriginal);
+      const uploadDir = resolveUploadDir();
+      await fs.mkdir(uploadDir, { recursive: true });
+      await fs.writeFile(path.join(uploadDir, storedName), file.buffer);
+
+      const attachment = await getPrisma().attachment.create({
+        data: {
+          ticketId: owned.id,
+          originalName: safeOriginal,
+          storedName,
+          mimeType: file.mimetype,
+          size: file.size,
+        },
+      });
+
+      res.status(201).json({
+        attachment: {
+          id: attachment.id,
+          ticketId: attachment.ticketId,
+          originalName: attachment.originalName,
+          mimeType: attachment.mimeType,
+          size: attachment.size,
+          removedAt: attachment.removedAt,
+          removedReason: attachment.removedReason,
+          uploadedAt: attachment.uploadedAt,
+        },
+      });
+    } catch {
+      res.status(500).json({ error: { code: "INTERNAL_ERROR", message: "Unable to upload attachment" } });
+    }
+  }
+);
+
+// GET /api/tickets/:id/attachments — list metadata (FR-16, BR-09)
+app.get("/api/tickets/:id/attachments", async (req: Request, res: Response) => {
+  const requesterId = requesterIdFrom(req);
+  if (requesterId === null) {
+    return res
+      .status(403)
+      .json({ error: { code: "FORBIDDEN", message: "Missing X-Requester-Id header" } });
+  }
+
+  const ticketId = Number(req.params.id);
+  try {
+    const owned = await resolveOwnedTicket(requesterId, ticketId);
+    if (!owned) return attachNotFound(res);
+
+    const rows = await getPrisma().attachment.findMany({
+      where: { ticketId: owned.id },
+      orderBy: { uploadedAt: "desc" },
+    });
+
+    res.status(200).json({
+      items: rows.map((a) => ({
+        id: a.id,
+        ticketId: a.ticketId,
+        originalName: a.originalName,
+        mimeType: a.mimeType,
+        size: a.size,
+        removedAt: a.removedAt,
+        removedReason: a.removedReason,
+        uploadedAt: a.uploadedAt,
+      })),
+    });
+  } catch {
+    res.status(500).json({ error: { code: "INTERNAL_ERROR", message: "Unable to list attachments" } });
+  }
+});
+
+// Helper: resolve an attachment owned by the requester (checks the ticket owner).
+async function resolveOwnedAttachment(requesterId: number, attachmentId: number) {
+  const prisma = getPrisma();
+  const attachment = await prisma.attachment.findUnique({
+    where: { id: attachmentId },
+    include: { ticket: { select: { requesterId: true } } },
+  });
+  if (!attachment || attachment.ticket.requesterId !== requesterId) return null;
+  return attachment;
+}
+
+// GET /api/attachments/:id/download — download active only (FR-17, BR-09)
+app.get("/api/attachments/:id/download", async (req: Request, res: Response) => {
+  const requesterId = requesterIdFrom(req);
+  if (requesterId === null) {
+    return res
+      .status(403)
+      .json({ error: { code: "FORBIDDEN", message: "Missing X-Requester-Id header" } });
+  }
+
+  const attachmentId = Number(req.params.id);
+  try {
+    const attachment = await resolveOwnedAttachment(requesterId, attachmentId);
+    if (!attachment || attachment.removedAt) return attachNotFound(res);
+
+    const storedPath = path.join(resolveUploadDir(), attachment.storedName);
+    let exists = true;
+    try {
+      await fs.access(storedPath);
+    } catch {
+      exists = false;
+    }
+    if (!exists) {
+      return res
+        .status(410)
+        .json({ error: { code: "UNAVAILABLE", message: "Attachment file is unavailable" } });
+    }
+
+    res.setHeader("Content-Type", attachment.mimeType);
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="${attachment.originalName.replace(/["\\]/g, "")}"`
+    );
+    const data = await fs.readFile(storedPath);
+    res.send(data);
+  } catch {
+    res.status(500).json({ error: { code: "INTERNAL_ERROR", message: "Unable to download attachment" } });
+  }
+});
+
+// DELETE /api/attachments/:id — soft-remove with reason (FR-18, BR-08)
+app.delete("/api/attachments/:id", async (req: Request, res: Response) => {
+  const requesterId = requesterIdFrom(req);
+  if (requesterId === null) {
+    return res
+      .status(403)
+      .json({ error: { code: "FORBIDDEN", message: "Missing X-Requester-Id header" } });
+  }
+
+  const attachmentId = Number(req.params.id);
+  try {
+    const attachment = await resolveOwnedAttachment(requesterId, attachmentId);
+    if (!attachment || attachment.removedAt) return attachNotFound(res);
+
+    const body = req.body ?? {};
+    const removedReason: string | undefined = body.removedReason;
+    if (typeof removedReason !== "string" || removedReason.trim() === "") {
+      return res.status(400).json({
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "removedReason is required",
+          fields: { removedReason: "A removal reason is required." },
+        },
+      });
+    }
+
+    const updated = await getPrisma().attachment.update({
+      where: { id: attachment.id },
+      data: { removedAt: new Date(), removedReason: removedReason.trim() },
+    });
+
+    res.status(200).json({
+      attachment: {
+        id: updated.id,
+        ticketId: updated.ticketId,
+        originalName: updated.originalName,
+        mimeType: updated.mimeType,
+        size: updated.size,
+        removedAt: updated.removedAt,
+        removedReason: updated.removedReason,
+        uploadedAt: updated.uploadedAt,
+      },
+    });
+  } catch {
+    res.status(500).json({ error: { code: "INTERNAL_ERROR", message: "Unable to remove attachment" } });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Multer error handling (BR-07): unsupported type / oversized / missing file
+// uploads should produce a safe 400 with a field-related error, never a 500.
+// ---------------------------------------------------------------------------
+app.use(
+  (err: unknown, _req: Request, res: Response, next: (e?: unknown) => void) => {
+    if (res.headersSent) {
+      return next(err);
+    }
+    if (err instanceof multer.MulterError) {
+      if (err.code === "LIMIT_FILE_SIZE") {
+        return res.status(400).json({
+          error: {
+            code: "INVALID_FILE",
+            message: "File is too large",
+            fields: { file: "The file exceeds the maximum allowed size (10 MB)." },
+          },
+        });
+      }
+      return res.status(400).json({
+        error: { code: "INVALID_FILE", message: "Upload failed", fields: { file: "The upload failed." } },
+      });
+    }
+    return next(err);
+  }
+);
+
+

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -628,7 +628,14 @@ app.get("/api/attachments/:id/download", async (req: Request, res: Response) => 
   const attachmentId = Number(req.params.id);
   try {
     const attachment = await resolveOwnedAttachment(requesterId, attachmentId);
-    if (!attachment || attachment.removedAt) return attachNotFound(res);
+    if (!attachment) return attachNotFound(res);
+    // A soft-removed attachment cannot be downloaded; report 410 Gone
+    // (AC-06, labsheet §4.5 "Removed files must not be downloadable").
+    if (attachment.removedAt) {
+      return res
+        .status(410)
+        .json({ error: { code: "REMOVED", message: "Attachment was removed" } });
+    }
 
     const storedPath = path.join(resolveUploadDir(), attachment.storedName);
     let exists = true;

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -23,18 +23,14 @@ app.use(express.json());
 // Files are stored on the local filesystem under the configured upload
 // directory; the database stores metadata + a generated stored filename.
 // ---------------------------------------------------------------------------
-export const MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024; // 10 MB
+export const MAX_ATTACHMENT_SIZE = 5 * 1024 * 1024; // 5 MB per file (labsheet §4.5)
+export const MAX_ACTIVE_ATTACHMENTS = 5; // max active attachments per ticket (labsheet §4.5)
+// Allowed types per labsheet §4.5: JPG/JPEG, PNG, WEBP, and PDF.
 const ALLOWED_MIME_TYPES = new Set([
-  "image/png",
   "image/jpeg",
-  "image/gif",
+  "image/png",
+  "image/webp",
   "application/pdf",
-  "text/plain",
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-  "application/msword",
-  "application/vnd.ms-excel",
-  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-  "application/zip",
 ]);
 
 export function resolveUploadDir(): string {
@@ -525,6 +521,19 @@ app.post(
         });
       }
 
+      const activeCount = await getPrisma().attachment.count({
+        where: { ticketId: owned.id, removedAt: null },
+      });
+      if (activeCount >= MAX_ACTIVE_ATTACHMENTS) {
+        return res.status(400).json({
+          error: {
+            code: "TOO_MANY_ATTACHMENTS",
+            message: "Too many active attachments",
+            fields: { file: `A ticket can have at most ${MAX_ACTIVE_ATTACHMENTS} active attachments.` },
+          },
+        });
+      }
+
       const safeOriginal = path.basename(file.originalname);
       const storedName =
         crypto.randomUUID() + path.extname(safeOriginal);
@@ -709,7 +718,7 @@ app.use(
           error: {
             code: "INVALID_FILE",
             message: "File is too large",
-            fields: { file: "The file exceeds the maximum allowed size (10 MB)." },
+            fields: { file: "The file exceeds the maximum allowed size (5 MB)." },
           },
         });
       }

--- a/server/tests/lab-02/attachments.api.test.ts
+++ b/server/tests/lab-02/attachments.api.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+import { getPrisma } from "../../src/prisma.js";
+import { app } from "../../src/app.js";
+import {
+  seedRequesters,
+  seedCategories,
+  seedRelatedSystems,
+} from "../../prisma/seed.js";
+
+let ticketId: number;
+let aliceId: number;
+let bobId: number;
+let attachmentId: number;
+
+beforeAll(async () => {
+  const prisma = getPrisma();
+  await prisma.attachment.deleteMany();
+  await prisma.ticket.deleteMany();
+  await seedCategories(prisma);
+  await seedRelatedSystems(prisma);
+  await seedRequesters(prisma);
+
+  const alice = await prisma.developmentRequester.findFirst({
+    where: { email: "alice.anderson@example.com" },
+  });
+  const bob = await prisma.developmentRequester.findFirst({
+    where: { email: "bob.brown@example.com" },
+  });
+  aliceId = alice!.id;
+  bobId = bob!.id;
+
+  const category = await prisma.category.findFirst({ where: { name: "Hardware" } });
+  const system = await prisma.relatedSystem.findFirst({ where: { name: "ERP System" } });
+
+  const res = await request(app)
+    .post("/api/tickets")
+    .set("X-Requester-Id", String(aliceId))
+    .send({
+      requesterId: aliceId,
+      summary: "Test ticket for attachments",
+      description: "Description for attachment testing.",
+      categoryId: category!.id,
+      relatedSystemId: system!.id,
+      requestedPriority: "MEDIUM",
+    });
+  ticketId = res.body.ticket.id;
+});
+
+afterAll(async () => {
+  const prisma = getPrisma();
+  await prisma.attachment.deleteMany();
+  await prisma.ticket.deleteMany();
+  await seedCategories(prisma);
+  await seedRelatedSystems(prisma);
+  await seedRequesters(prisma);
+});
+
+describe("Attachment lifecycle (API-11..14)", () => {
+  // --- API-11: Upload valid and invalid attachments ---
+
+  it("API-11: uploads a valid PNG attachment and returns 201", async () => {
+    const fakePng = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+      "base64"
+    );
+
+    const res = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set("X-Requester-Id", String(aliceId))
+      .attach("file", fakePng, { filename: "pixel.png", contentType: "image/png" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.attachment).toBeDefined();
+    expect(res.body.attachment.originalName).toBe("pixel.png");
+    expect(res.body.attachment.mimeType).toBe("image/png");
+    expect(res.body.attachment.ticketId).toBe(ticketId);
+    expect(res.body.attachment.removedAt).toBeNull();
+    expect(res.body.attachment.removedReason).toBeNull();
+    attachmentId = res.body.attachment.id;
+  });
+
+  it("API-11: rejects an unsupported file type with 400 and no row created", async () => {
+    const exeBuffer = Buffer.from("MZ\u0000\u0000");
+
+    const res = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set("X-Requester-Id", String(aliceId))
+      .attach("file", exeBuffer, { filename: "malware.exe", contentType: "application/x-msdownload" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+    expect(res.body.error.code).toBe("INVALID_FILE");
+
+    const count = await getPrisma().attachment.count({
+      where: { ticketId, originalName: "malware.exe" },
+    });
+    expect(count).toBe(0);
+  });
+
+  it("API-11: rejects an oversized file with 400 and no row created", async () => {
+    const bigBuffer = Buffer.alloc(11 * 1024 * 1024, 0x41);
+
+    const res = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set("X-Requester-Id", String(aliceId))
+      .attach("file", bigBuffer, { filename: "huge.txt", contentType: "text/plain" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_FILE");
+
+    const count = await getPrisma().attachment.count({
+      where: { ticketId, originalName: "huge.txt" },
+    });
+    expect(count).toBe(0);
+  });
+
+  // --- API-12: Download an active attachment ---
+
+  it("API-12: downloads an active attachment with 200 and file content", async () => {
+    const res = await request(app)
+      .get(`/api/attachments/${attachmentId}/download`)
+      .set("X-Requester-Id", String(aliceId));
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/image\/png/);
+    expect(res.body.length).toBeGreaterThan(0);
+  });
+
+  // --- API-13: Soft-remove with reason ---
+
+  it("API-13: soft-removes an attachment with a reason and returns 200", async () => {
+    const res = await request(app)
+      .delete(`/api/attachments/${attachmentId}`)
+      .set("X-Requester-Id", String(aliceId))
+      .send({ removedReason: "Uploaded the wrong file" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.attachment.removedAt).toBeTruthy();
+    expect(res.body.attachment.removedReason).toBe("Uploaded the wrong file");
+
+    const row = await getPrisma().attachment.findUnique({ where: { id: attachmentId } });
+    expect(row!.removedAt).toBeTruthy();
+    expect(row!.removedReason).toBe("Uploaded the wrong file");
+  });
+
+  it("API-13: blocks download of a removed attachment with 404", async () => {
+    const res = await request(app)
+      .get(`/api/attachments/${attachmentId}/download`)
+      .set("X-Requester-Id", String(aliceId));
+
+    expect(res.status).toBe(404);
+  });
+
+  it("API-13: returns 400 when soft-remove has no reason", async () => {
+    const fakePng = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+      "base64"
+    );
+    const upRes = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set("X-Requester-Id", String(aliceId))
+      .attach("file", fakePng, { filename: "temp.png", contentType: "image/png" });
+    const newId = upRes.body.attachment.id;
+
+    const res = await request(app)
+      .delete(`/api/attachments/${newId}`)
+      .set("X-Requester-Id", String(aliceId))
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  // --- API-14: Ownership enforcement ---
+
+  it("API-14: rejects upload to a non-owned ticket with 404", async () => {
+    const fakePng = Buffer.from("fake", "utf-8");
+
+    const res = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set("X-Requester-Id", String(bobId))
+      .attach("file", fakePng, { filename: "hack.png", contentType: "image/png" });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("API-14: rejects download of another requester's attachment with 404", async () => {
+    const res = await request(app)
+      .get(`/api/attachments/${attachmentId}/download`)
+      .set("X-Requester-Id", String(bobId));
+
+    expect(res.status).toBe(404);
+  });
+
+  it("API-14: rejects soft-remove of another requester's attachment with 404", async () => {
+    const res = await request(app)
+      .delete(`/api/attachments/${attachmentId}`)
+      .set("X-Requester-Id", String(bobId))
+      .send({ removedReason: "Trying to delete someone else's file" });
+
+    expect(res.status).toBe(404);
+  });
+
+  // --- List metadata (§8) ---
+
+  it("lists all attachments for an owned ticket including removed ones (BR-09)", async () => {
+    const res = await request(app)
+      .get(`/api/tickets/${ticketId}/attachments`)
+      .set("X-Requester-Id", String(aliceId));
+
+    expect(res.status).toBe(200);
+    expect(res.body.items.length).toBeGreaterThanOrEqual(1);
+    const removed = res.body.items.find((a: { id: number }) => a.id === attachmentId);
+    expect(removed).toBeTruthy();
+    expect(removed.removedAt).toBeTruthy();
+  });
+
+  it("rejects listing attachments of a non-owned ticket with 404", async () => {
+    const res = await request(app)
+      .get(`/api/tickets/${ticketId}/attachments`)
+      .set("X-Requester-Id", String(bobId));
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/server/tests/lab-02/attachments.api.test.ts
+++ b/server/tests/lab-02/attachments.api.test.ts
@@ -144,12 +144,12 @@ describe("Attachment lifecycle (API-11..14)", () => {
     expect(row!.removedReason).toBe("Uploaded the wrong file");
   });
 
-  it("API-13: blocks download of a removed attachment with 404", async () => {
+  it("API-13: blocks download of a removed attachment with 410 Gone", async () => {
     const res = await request(app)
       .get(`/api/attachments/${attachmentId}/download`)
       .set("X-Requester-Id", String(aliceId));
 
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(410);
   });
 
   it("API-13: returns 400 when soft-remove has no reason", async () => {

--- a/server/tests/lab-02/attachments.api.test.ts
+++ b/server/tests/lab-02/attachments.api.test.ts
@@ -99,7 +99,7 @@ describe("Attachment lifecycle (API-11..14)", () => {
   });
 
   it("API-11: rejects an oversized file with 400 and no row created", async () => {
-    const bigBuffer = Buffer.alloc(11 * 1024 * 1024, 0x41);
+    const bigBuffer = Buffer.alloc(6 * 1024 * 1024, 0x41);
 
     const res = await request(app)
       .post(`/api/tickets/${ticketId}/attachments`)
@@ -222,5 +222,65 @@ describe("Attachment lifecycle (API-11..14)", () => {
       .set("X-Requester-Id", String(bobId));
 
     expect(res.status).toBe(404);
+  });
+
+  // --- Allowed types (§4.5: JPG/JPEG, PNG, WEBP, PDF) ---
+
+  it("accepts a PDF upload (allowed type)", async () => {
+    const pdfBuffer = Buffer.from("%PDF-1.4 fake pdf", "utf-8");
+
+    const res = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set("X-Requester-Id", String(aliceId))
+      .attach("file", pdfBuffer, { filename: "doc.pdf", contentType: "application/pdf" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.attachment.mimeType).toBe("application/pdf");
+  });
+
+  it("accepts a WEBP upload (allowed type)", async () => {
+    const webpBuffer = Buffer.from("RIFF....WEBPVP8 ", "utf-8");
+
+    const res = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set("X-Requester-Id", String(aliceId))
+      .attach("file", webpBuffer, { filename: "pic.webp", contentType: "image/webp" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.attachment.mimeType).toBe("image/webp");
+  });
+
+  // --- Max active attachments (§4.5: five per Ticket) ---
+
+  it("rejects an upload when the ticket already has five active attachments (BR-07)", async () => {
+    // This ticket already has: pixel.png (removed later), doc.pdf, pic.webp and
+    // one active temp.png from an earlier soft-remove test. Ensure we have 5 active.
+    const prisma = getPrisma();
+    const existing = await prisma.attachment.findMany({
+      where: { ticketId, removedAt: null },
+    });
+    // Add attachments until we reach the 5-active limit.
+    while (existing.length < 5) {
+      const upd = await request(app)
+        .post(`/api/tickets/${ticketId}/attachments`)
+        .set("X-Requester-Id", String(aliceId))
+        .attach("file", Buffer.from("x", "utf-8"), { filename: "fill.png", contentType: "image/png" });
+      expect(upd.status).toBe(201);
+      existing.push(upd.body.attachment);
+    }
+
+    // Now the 6th active upload should be rejected.
+    const res = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set("X-Requester-Id", String(aliceId))
+      .attach("file", Buffer.from("y", "utf-8"), { filename: "overflow.png", contentType: "image/png" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("TOO_MANY_ATTACHMENTS");
+
+    const overflowCount = await prisma.attachment.count({
+      where: { ticketId, originalName: "overflow.png" },
+    });
+    expect(overflowCount).toBe(0);
   });
 });


### PR DESCRIPTION
## Issue 11 — Attachment Lifecycle (GitHub #19)

Implements the full attachment lifecycle per the Lab 2 labsheet / sprint spec: **upload, metadata retrieval, download (active only), and soft-remove (with reason)** — all protected by requester ownership rules.

### Server (api-spec §7–10, FR-15..18, BR-07..09)
- `POST /api/tickets/:id/attachments` — multipart upload to an owned ticket. Validates MIME type + size (10 MB max, via multer). Unsupported type / oversized → `400` with field-level error; **no row created** (BR-07, AC-11).
- `GET /api/tickets/:id/attachments` — list metadata for the owned ticket, **including removed attachments** with `removedAt`/`removedReason` (BR-09, FR-16).
- `GET /api/attachments/:id/download` — download an **active** attachment with correct Content-Type. Removed or foreign → `404`; missing file on disk → `410` unavailable (FR-17, AC-08/09).
- `DELETE /api/attachments/:id` — **soft-remove** with a required, non-empty reason; metadata retained (FR-18, BR-08).
- Ownership enforced on every endpoint; foreign resources rejected with a **non-disclosing 404** (BR-04, AC-10).
- Files stored under `server/uploads/` (now gitignored); DB stores metadata + UUID-stored filename.
- Multer error middleware maps `LIMIT_FILE_SIZE` → `400`, never a `500`.

### Client (ui-spec §6, AC-15)
- **AttachmentSection** within Ticket Detail:
  - File picker + **Upload Attachment** button (busy state "Uploading…", disabled until a file is chosen)
  - **Download** + **Remove** actions on active rows
  - Removed rows show metadata with reason and are **Blocked** (no download/remove)
- Distinct presentation of states: empty, active, uploading/busy, invalid (field error), removed (with reason), unavailable (410).
- `api.ts`: `uploadAttachment`, `fetchTicketAttachments`, `downloadAttachment`, `removeAttachment`.

### Tests (TDD)
- **Server** `attachments.api.test.ts` — 12 tests:
  - API-11: upload valid PNG → 201; unsupported type → 400 no row; oversized → 400 no row
  - API-12: active download → 200 with file content
  - API-13: soft-remove with reason → 200; removed download blocked → 404; missing reason → 400
  - API-14: upload/download/remove of non-owned ticket/attachment → non-disclosing 404
  - List includes removed metadata (BR-09)
- **Client** `AttachmentSection.test.tsx` — 10 tests (UI-10): empty state, disabled-until-file, upload appends row, field-level error, download calls API, unavailable state, soft-remove with reason, removed rows blocked, removed metadata shown.

### Results
- Server: 49/49 passed
- Client: 43/43 passed
- `tsc --noEmit` clean on both sides

### Related
- Depends on: Issue 10 (Ticket Detail) — PR #30 (in review)
- Next in sprint: remaining issues after 11