### PR TITLE
feat(Issue 12): Zen Green UI & Responsive — tokens, button hierarchy, focus, STYLE-01 tests

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16,6 +16,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",
+        "@types/node": "^26.4.1",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^4.3.4",
@@ -1529,6 +1530,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
+      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -3028,6 +3039,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.3.1",

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
+    "@types/node": "^26.4.1",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -110,6 +110,10 @@ export default function App() {
   }
 
   const myTicketsActive = view !== "create-ticket";
+  const createTicketActive = view === "create-ticket";
+  // ui-spec §8 / §13: the active view is exposed to assistive tech via
+  // aria-current="page" so screen readers announce the current navigation item.
+  const currentPageFor = (active: boolean) => (active ? "page" : undefined);
 
   return (
     <div className="app-shell">
@@ -143,16 +147,16 @@ export default function App() {
               className={`nav-link ${myTicketsActive ? "active" : ""}`}
               style={myTicketsActive ? { background: "#0B7A46" } : { color: "#fff" }}
               onClick={() => setView("my-tickets")}
-              aria-current={myTicketsActive ? "page" : undefined}
+              aria-current={currentPageFor(myTicketsActive)}
             >
               My Tickets
             </button>
             <button
               type="button"
-              className={`nav-link ${view === "create-ticket" ? "active" : ""}`}
-              style={view === "create-ticket" ? { background: "#0B7A46" } : { color: "#fff" }}
+              className={`nav-link ${createTicketActive ? "active" : ""}`}
+              style={createTicketActive ? { background: "#0B7A46" } : { color: "#fff" }}
               onClick={() => setView("create-ticket")}
-              aria-current={view === "create-ticket" ? "page" : undefined}
+              aria-current={currentPageFor(createTicketActive)}
             >
               Create Ticket
             </button>

--- a/client/src/TicketDetail.tsx
+++ b/client/src/TicketDetail.tsx
@@ -147,7 +147,7 @@ function AttachmentSection({
         {uploadError && <p className="text-danger small">{uploadError}</p>}
         {removeError && <p className="text-danger small">{removeError}</p>}
         {unavailableError && (
-          <p className="text-warning small">
+          <p className="callout-warning px-2 py-1 small mb-3" role="alert">
             The file "{unavailableError}" is not available on the server.
           </p>
         )}
@@ -202,7 +202,7 @@ function AttachmentSection({
                             </button>
                             <button
                               type="button"
-                              className="btn btn-outline-danger btn-sm"
+                              className="btn btn-tok-danger btn-sm"
                               onClick={() => handleRemove(a)}
                               disabled={isDownloading || isRemoving}
                             >

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -5,13 +5,70 @@
   --tok-secondary: #0b7a46;
   --tok-pale: #eaf6ef;
   --tok-bg: #f5f7f6;
+  --tok-surface: #ffffff;
   --tok-text: #1c2b22;
+  --tok-field: #ffffff;
   --tok-readonly: #eef2f0;
+  --tok-error: #b00020;
+  --tok-warning: #b8860b;
+  --tok-success: #198754;
 }
 
 body {
   background-color: var(--tok-bg);
   color: var(--tok-text);
+}
+
+/* Zen Green card/surface: white with a subtle border and restrained shadow. */
+.app-card {
+  background-color: var(--tok-surface);
+  border: 1px solid #e3e8e5;
+  border-radius: 0.5rem;
+  box-shadow: 0 1px 2px rgba(28, 43, 34, 0.06);
+}
+
+/* Application header identity (primary green). */
+.app-header {
+  background-color: var(--tok-primary);
+}
+
+/* Visible keyboard focus indicators (secondary green). */
+.form-control:focus,
+.form-select:focus,
+.form-check-input:focus,
+.btn:focus-visible,
+.nav-link:focus-visible,
+input[type="file"]:focus-visible {
+  border-color: var(--tok-secondary);
+  box-shadow: 0 0 0 0.2rem rgba(11, 122, 70, 0.25);
+  outline: none;
+}
+
+/* Warning is an amber callout/badge only, never ordinary decoration. */
+.callout-warning {
+  background-color: #fdf3dc;
+  border-left: 0.25rem solid var(--tok-warning);
+  color: #5a4a00;
+}
+
+/* Success is green confirmation with readable text (not color-alone). */
+.text-tok-success {
+  color: var(--tok-success);
+}
+
+/* Error message text (dark red, readable). */
+.text-tok-error {
+  color: var(--tok-error);
+}
+
+/* Respect reduced-motion preferences for focus transitions. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    transition-duration: 0.001ms !important;
+  }
 }
 
 /* Read-only fields must be visually distinct from editable ones. */
@@ -42,6 +99,26 @@ body {
   background-color: var(--tok-primary);
   border-color: var(--tok-primary);
   color: #fff;
+}
+
+/* Destructive (ui-spec §5): used for soft-remove attachment actions. */
+.btn-tok-danger {
+  background-color: var(--tok-error);
+  border-color: var(--tok-error);
+  color: #fff;
+}
+.btn-tok-danger:hover,
+.btn-tok-danger:focus {
+  background-color: #8f0019;
+  border-color: #8f0019;
+  color: #fff;
+}
+
+/* Disabled controls are visually distinct and not activatable. */
+.btn:disabled,
+.btn[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 /* Badges (ui-spec §10): Requested Priority follows an escalating severity

--- a/client/tests/lab-02/style.test.tsx
+++ b/client/tests/lab-02/style.test.tsx
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import CreateTicket from "../../src/CreateTicket.js";
@@ -58,17 +60,10 @@ const TICKET_RESP = {
 
 describe("Zen Green UI style (STYLE-01, ui-spec)", () => {
   it("keeps Zen Green color tokens in :root (ui-spec §1)", () => {
-    const cssText = `
-      :root {
-        --tok-primary: #006b3c;
-        --tok-secondary: #0b7a46;
-        --tok-pale: #eaf6ef;
-        --tok-bg: #f5f7f6;
-        --tok-surface: #ffffff;
-        --tok-text: #1c2b22;
-        --tok-readonly: #eef2f0;
-      }`;
-    // The source-of-truth tokens are defined in styles.css; assert they exist.
+    const cssText = readFileSync(
+      resolve(__dirname, "../../src/styles.css"),
+      "utf-8"
+    );
     const root = cssText.match(/--tok-\w+/g) ?? [];
     for (const token of [
       "--tok-primary",
@@ -92,16 +87,20 @@ describe("Zen Green UI style (STYLE-01, ui-spec)", () => {
     expect(container.querySelector('label[for="description"]')).toHaveTextContent("*");
   });
 
-  it("shows near-field validation messages directly below fields (ui-spec §4)", async () => {
+  it("shows near-field validation messages and marks invalid fields (ui-spec §4)", async () => {
     vi.spyOn(api, "fetchCategories").mockResolvedValue(CATEGORIES);
     vi.spyOn(api, "fetchRelatedSystems").mockResolvedValue(SYSTEMS);
     const user = userEvent.setup();
-    render(<CreateTicket requester={ALICE} />);
+    const { container } = render(<CreateTicket requester={ALICE} />);
 
     await user.click(await screen.findByRole("button", { name: /Submit Ticket/i }));
 
     expect(screen.getByText(/Summary is required/i)).toBeInTheDocument();
     expect(screen.getByText(/Description is required/i)).toBeInTheDocument();
+
+    // Invalid fields must be visually marked with the is-invalid class (ui-spec §3).
+    expect(container.querySelector("#summary")).toHaveClass("is-invalid");
+    expect(container.querySelector("#description")).toHaveClass("is-invalid");
   });
 
   it("marks invalid fields and keeps the submit button in a disabled state while busy (ui-spec §3, §5)", async () => {
@@ -179,9 +178,20 @@ describe("Zen Green UI style (STYLE-01, ui-spec)", () => {
     await user.selectOptions(combobox, "1");
     await user.click(screen.getByRole("button", { name: /Continue/i }));
 
-    expect(screen.getByRole("button", { name: "My Tickets" })).toHaveAttribute(
-      "aria-current",
-      "page"
+    expect(
+      screen.getByRole("button", { name: "My Tickets" })
+    ).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("button", { name: "Create Ticket" })).not.toHaveAttribute(
+      "aria-current"
+    );
+
+    // The aria-current indicator must move with the active tab.
+    await user.click(screen.getByRole("button", { name: "Create Ticket" }));
+    expect(
+      screen.getByRole("button", { name: "Create Ticket" })
+    ).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("button", { name: "My Tickets" })).not.toHaveAttribute(
+      "aria-current"
     );
   });
 });

--- a/client/tests/lab-02/style.test.tsx
+++ b/client/tests/lab-02/style.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CreateTicket from "../../src/CreateTicket.js";
+import TicketDetail from "../../src/TicketDetail.js";
+import App from "../../src/App.js";
+import * as api from "../../src/api.js";
+
+// STYLE-01 — automated assertions for required CSS classes, field states,
+// labels, asterisks, messages, and button busy/disabled (ui-spec AC-13).
+
+const ALICE = { id: 1, name: "Alice Anderson", email: "alice@example.com" };
+
+const CATEGORIES = [{ id: 1, name: "Hardware" }];
+const SYSTEMS = [{ id: 1, name: "ERP System", type: "Application" }];
+
+const MY_TICKET: api.MyTicket = {
+  ticketNumber: "TK-000007",
+  id: 7,
+  summary: "Laptop battery drains quickly",
+  category: { id: 1, name: "Hardware" },
+  requestedPriority: "HIGH",
+  itPriority: "MEDIUM",
+  currentStatus: "IN_PROGRESS",
+  updatedAt: "2026-09-01T10:00:00.000Z",
+};
+
+const FULL_DETAIL: api.TicketDetail = {
+  ticketNumber: "TK-000007",
+  id: 7,
+  summary: "Laptop battery drains quickly",
+  description: "Battery drops fast.",
+  requesterId: 1,
+  category: { id: 1, name: "Hardware" },
+  relatedSystem: { id: 1, name: "ERP System", type: "Application" },
+  requestedPriority: "HIGH",
+  itPriority: "MEDIUM",
+  currentStatus: "IN_PROGRESS",
+  createdAt: "2026-09-01T08:00:00.000Z",
+  updatedAt: "2026-09-01T10:00:00.000Z",
+  attachments: [],
+};
+
+const TICKET_RESP = {
+  ticketNumber: "TK-000001",
+  id: 1,
+  summary: "x",
+  description: "y",
+  requesterId: 1,
+  category: { id: 1, name: "Hardware" },
+  relatedSystem: { id: 1, name: "ERP System" },
+  requestedPriority: "MEDIUM" as const,
+  itPriority: "MEDIUM" as const,
+  currentStatus: "SUBMITTED",
+  createdAt: "2026-09-01T00:00:00.000Z",
+  updatedAt: "2026-09-01T00:00:00.000Z",
+};
+
+describe("Zen Green UI style (STYLE-01, ui-spec)", () => {
+  it("keeps Zen Green color tokens in :root (ui-spec §1)", () => {
+    const cssText = `
+      :root {
+        --tok-primary: #006b3c;
+        --tok-secondary: #0b7a46;
+        --tok-pale: #eaf6ef;
+        --tok-bg: #f5f7f6;
+        --tok-surface: #ffffff;
+        --tok-text: #1c2b22;
+        --tok-readonly: #eef2f0;
+      }`;
+    // The source-of-truth tokens are defined in styles.css; assert they exist.
+    const root = cssText.match(/--tok-\w+/g) ?? [];
+    for (const token of [
+      "--tok-primary",
+      "--tok-secondary",
+      "--tok-pale",
+      "--tok-bg",
+      "--tok-surface",
+      "--tok-text",
+      "--tok-readonly",
+    ]) {
+      expect(root).toContain(token);
+    }
+  });
+
+  it("renders required-field red asterisks on Summary and Description (ui-spec §3)", async () => {
+    vi.spyOn(api, "fetchCategories").mockResolvedValue(CATEGORIES);
+    vi.spyOn(api, "fetchRelatedSystems").mockResolvedValue(SYSTEMS);
+    const { container } = render(<CreateTicket requester={ALICE} />);
+
+    expect(container.querySelector('label[for="summary"]')).toHaveTextContent("*");
+    expect(container.querySelector('label[for="description"]')).toHaveTextContent("*");
+  });
+
+  it("shows near-field validation messages directly below fields (ui-spec §4)", async () => {
+    vi.spyOn(api, "fetchCategories").mockResolvedValue(CATEGORIES);
+    vi.spyOn(api, "fetchRelatedSystems").mockResolvedValue(SYSTEMS);
+    const user = userEvent.setup();
+    render(<CreateTicket requester={ALICE} />);
+
+    await user.click(await screen.findByRole("button", { name: /Submit Ticket/i }));
+
+    expect(screen.getByText(/Summary is required/i)).toBeInTheDocument();
+    expect(screen.getByText(/Description is required/i)).toBeInTheDocument();
+  });
+
+  it("marks invalid fields and keeps the submit button in a disabled state while busy (ui-spec §3, §5)", async () => {
+    vi.spyOn(api, "fetchCategories").mockResolvedValue(CATEGORIES);
+    vi.spyOn(api, "fetchRelatedSystems").mockResolvedValue(SYSTEMS);
+    let resolveFn!: (v: typeof TICKET_RESP) => void;
+    const createSpy = vi
+      .spyOn(api, "createTicket")
+      .mockReturnValue(new Promise((resolve) => { resolveFn = resolve; }));
+
+    render(<CreateTicket requester={ALICE} />);
+    const user = userEvent.setup();
+    // Wait until the reference-data selects have their options loaded.
+    const combos = await screen.findAllByRole("combobox");
+    await user.selectOptions(combos[0], "1"); // Category
+    await user.selectOptions(combos[1], "1"); // Related System
+    await user.type(screen.getByLabelText(/Summary/i), "x");
+    await user.type(screen.getByLabelText(/Description/i), "y");
+    await user.click(screen.getByRole("button", { name: /Submit Ticket/i }));
+
+    expect(createSpy).toHaveBeenCalled();
+    const busyBtn = screen.getByRole("button", { name: /Submitting…/i });
+    expect(busyBtn).toBeDisabled();
+  });
+
+  it("renders read-only system fields distinctly from editable ones (ui-spec §3)", async () => {
+    vi.spyOn(api, "fetchCategories").mockResolvedValue(CATEGORIES);
+    vi.spyOn(api, "fetchRelatedSystems").mockResolvedValue(SYSTEMS);
+    const { container } = render(<CreateTicket requester={ALICE} />);
+    const readonly = container.querySelectorAll(".readonly-field");
+    expect(readonly.length).toBeGreaterThan(0);
+  });
+
+  it("applies badge classes for Requested Priority, IT Priority, and Current Status (ui-spec §10)", async () => {
+    vi.spyOn(api, "fetchTicketDetail").mockResolvedValue(FULL_DETAIL);
+    render(
+      <TicketDetail requester={ALICE} ticket={MY_TICKET} onBack={() => {}} />
+    );
+
+    expect(await screen.findByText("HIGH")).toBeInTheDocument();
+    expect(screen.getByText("HIGH").className).toContain("badge-priority-high");
+    expect(screen.getByText("MEDIUM").className).toContain("badge-priority-medium");
+    expect(screen.getByText("IN_PROGRESS").className).toContain("badge-status-in-progress");
+  });
+
+  it("shows a disabled Continue button until a requester is chosen (ui-spec §3)", async () => {
+    vi.spyOn(api, "fetchDevelopmentRequesters").mockResolvedValue([ALICE]);
+    vi.spyOn(api, "fetchMyTickets").mockResolvedValue({
+      items: [MY_TICKET as api.MyTicket],
+      pagination: { page: 1, pageSize: 10, total: 1, totalPages: 1 },
+      filtersApplied: {},
+    });
+    vi.spyOn(api, "fetchTicketDetail").mockResolvedValue(FULL_DETAIL);
+    vi.spyOn(api, "fetchCategories").mockResolvedValue(CATEGORIES);
+    vi.spyOn(api, "fetchRelatedSystems").mockResolvedValue(SYSTEMS);
+    render(<App />);
+    const continueBtn = await screen.findByRole("button", { name: /Continue/i });
+    expect(continueBtn).toBeDisabled();
+  });
+
+  it("indicates the active navigation page with aria-current (ui-spec §8)", async () => {
+    vi.spyOn(api, "fetchDevelopmentRequesters").mockResolvedValue([ALICE]);
+    vi.spyOn(api, "fetchMyTickets").mockResolvedValue({
+      items: [MY_TICKET as api.MyTicket],
+      pagination: { page: 1, pageSize: 10, total: 1, totalPages: 1 },
+      filtersApplied: {},
+    });
+    vi.spyOn(api, "fetchTicketDetail").mockResolvedValue(FULL_DETAIL);
+    vi.spyOn(api, "fetchCategories").mockResolvedValue(CATEGORIES);
+    vi.spyOn(api, "fetchRelatedSystems").mockResolvedValue(SYSTEMS);
+
+    const user = userEvent.setup();
+    render(<App />);
+    const combobox = await screen.findByRole("combobox", { name: /Development Requester/i });
+    await user.selectOptions(combobox, "1");
+    await user.click(screen.getByRole("button", { name: /Continue/i }));
+
+    expect(screen.getByRole("button", { name: "My Tickets" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+  });
+});


### PR DESCRIPTION
## Issue 12 — Zen Green UI & Responsive (GitHub #20)

Polish and complete the reusable **Zen Green** presentation system (ui-spec.md) across all Lab 2 screens.

### What changed
- **`client/src/styles.css`** — complete the ui-spec token set and reusable rules:
  - Tokens (ui-spec §1): `--tok-surface`, `--tok-field`, `--tok-error`, `--tok-warning`, `--tok-success` added to the existing primary/secondary/pale/bg/text/readonly
  - `.app-card` — white card with subtle border + restrained shadow (`--tok-surface`)
  - `.app-header` — primary green identity header (`#006B3C`)
  - **Visible keyboard focus indicators** (ui-spec §3/§13) on inputs, selects, buttons, nav-links with a secondary-green focus ring + outline
  - `@media (prefers-reduced-motion: reduce)` support (accessibility)
  - `.callout-warning` — amber callout only for warnings (never ordinary decoration)
  - `.text-tok-success` / `.text-tok-error` helpers (readable text, not color-alone)
  - `.btn-tok-danger` — **destructive** button for soft-remove (ui-spec §5)
  - Explicit disabled-button styling (distinct + `not-allowed`, §3)
- **`client/src/TicketDetail.tsx`** — soft-remove action now uses `.btn-tok-danger`; the unavailable-file state uses `.callout-warning` with `role="alert"` (alignment with ui-spec §5/§6, warning token).
- **`client/tests/lab-02/style.test.tsx`** — **STYLE-01** (AC-13) automated assertions for the required CSS classes, field states, labels, asterisks, messages, and button busy/disabled behavior:
  - color tokens present in `:root`
  - required-field red asterisks on Summary/Description
  - near-field validation messages
  - invalid fields + disabled busy "Submitting…" submit
  - read-only fields visually distinct (`.readonly-field`)
  - Requested/IT Priority and Current Status badge classes
  - disabled "Continue" until a requester is selected
  - `aria-current="page"` active-page indication

### Tests
- Client: **51/51** passing
- `tsc --noEmit` clean

### References
- `docs/lab-02/ui-spec.md` §1 (tokens), §3 (control states), §4 (validation placement), §5 (button hierarchy incl. destructive + busy), §6 (attachment/unavailable), §8 (shell + active nav), §13 (accessibility)
- `docs/lab-02/tests.md` STYLE-01 / AC-13
- Rubric Part 9 (Zen Green UI and Responsive Evidence)

### Related
- Depends on: Issue 11 (Attachment lifecycle) — merged via PR #31
- Next in sprint: remaining issues after 12