### PR TITLE
docs(Issue 15): finalize Lab 2 docs — reviewer, ai-use, README, final status

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,15 @@ toktickit/
  ├── server/                  # Node.js + Express + TypeScript backend
  │   ├── prisma/              # Prisma schema, migrations, seed
  │   ├── src/                 # Express app and routes
- │   └── tests/lab-01/        # Supertest API tests
+ │   └── tests/lab-01, lab-02 # Supertest API tests (Lab 2: create/my-tickets/ticket-detail/attachments)
+ ├── e2e/lab-02/              # Playwright E2E + responsive specs
+ ├── scripts/                 # screenshots.mjs (Playwright screenshot generator)
  ├── docs/lab-01/             # ai_use.md, reviewer.md, tests.md
+ ├── docs/lab-02/             # specification.md, api-spec.md, ui-spec.md, tests.md,
+ │                            #   reviewer.md, ai-use.md, visual-inspection.md
+ ├── artifacts/lab-02/screenshots/  # evidence PNGs (create-ticket, my-tickets, ticket-detail)
+ ├── playwright.config.ts     # E2E projects: desktop/tablet/mobile
+ ├── package.json             # root scripts: test:e2e, screenshots
  ├── .gitignore
  └── README.md
 ```
@@ -32,7 +39,7 @@ cd server
 cp .env.example .env        # then edit DATABASE_URL / PORT for your machine
 npm install
 npx prisma migrate dev      # create the database schema
-npx prisma db seed          # insert the four default categories
+npx prisma db seed          # insert categories, related systems, and requesters
 npm run dev                 # API on http://localhost:3000
 ```
 
@@ -45,13 +52,27 @@ npm install
 npm run dev                 # Vite dev server
 ```
 
-Open the Vite URL (default http://localhost:5173), click **Check System** and you
-should see the system status and the four supported request categories loaded
-from PostgreSQL.
+Open the Vite URL (default http://localhost:5173). Select a Development Requester,
+then use the app (Lab 2):
+
+- **Create Ticket** — pick a category / related system, enter subject + description,
+  and upload attachments; validation errors appear next to the field; a `TK-######`
+  ticket number is generated.
+- **My Tickets** — search, filter, sort, and paginate the requester's own tickets.
+- **Ticket Detail** — view an ownership-scoped ticket with its attachment list,
+  upload/download, and soft-remove.
+
+A **Health Check** of the API is available at http://localhost:3000/api/health.
 
 ### Tests
 
 ```bash
 cd server && npm test       # Supertest API tests (Vitest)
 cd client && npm test       # UI tests (Vitest + Testing Library)
+npm run test:e2e            # Playwright E2E + responsive (root; starts server on :3000, client on :5173)
+npm run screenshots         # regenerate desktop/tablet/mobile evidence PNGs into artifacts/
+```
+
+Lab 2 test results: server 52/52, client 51/51, E2E + responsive 11/11 (see
+`docs/lab-02/tests.md`).
 ```

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ A **Health Check** of the API is available at http://localhost:3000/api/health.
 ```bash
 cd server && npm test       # Supertest API tests (Vitest)
 cd client && npm test       # UI tests (Vitest + Testing Library)
-npm run test:e2e            # Playwright E2E + responsive (root; starts server on :3000, client on :5173)
+npm run test:e2e            # Playwright E2E + responsive (root; starts the client on :5173).
+                            # Start the API first on :3000 with `cd server && npm run dev`.
 npm run screenshots         # regenerate desktop/tablet/mobile evidence PNGs into artifacts/
 ```
 

--- a/docs/lab-02/ai-use.md
+++ b/docs/lab-02/ai-use.md
@@ -5,24 +5,34 @@ that writes and verifies code directly in this repository (Spec-Driven Developme
 
 ## Selected key prompts (6–10)
 
-| # | Prompt (summarised) | What I did with the result |
-|---|---------------------|----------------------------|
-| 1 | "Turn the Lab 2 labs sheet into a complete engineering contract: scope, user stories, non-functional requirements, and the test plan." | Produced `docs/lab-02/specification.md` + `api-spec.md` + `ui-spec.md` (Issue 5) — the single source of truth every later Issue verified against. |
-| 2 | "Design the Lab 2 relational model and seed data from the specs." | Wrote the Prisma schema (Ticket, Attachment, Requested/IT Priority + Current Status enums), migration, and 6-category / related-system / requester seed (Issue 6). |
-| 3 | "Write a failing test first, then implement ticket creation and its Create Ticket screen (TDD)." | Added the create-ticket API + UI test first, then the implementation that turns it green (Issue 8); confirm validation errors are shown near the field. |
-| 4 | "Implement My Tickets with search, filters, sorting, and pagination, scoped to the requester." | Added the ownership-scoped list API + My Tickets screen + tests (Issue 9). |
-| 5 | "Add the Zen Green theme: CSS tokens, button hierarchy, focus states, and responsive breakpoints from ui-spec §7/§12." | Built the token-based stylesheet, active-nav accessibility, and STYLE-01 tests that read the real `styles.css` (Issue 12). |
-| 6 | "Set up Playwright E2E that exercises the full requester flow and the responsive rules, with screenshots at desktop/tablet/mobile." | Wrote `playwright.config.ts` (3 chromium projects, `workers: 1`) plus `requester-ticket-flow` / `responsive` specs and `npm run screenshots` (Issue 13). |
-| 7 | "The reviewer says the E2E can't pass — re-verify against the actual remote staging and push back with evidence." | Ran `git ls-tree` / `git show` on `origin/lab2-staging` and re-ran the suite (11/11 pass), then replied with code evidence and conceded the one real status gap (Issue 13 review). |
-| 8 | "Produce the visual-inspection evidence: complete the ui-spec §14 checklist and regenerate current screenshots." | Wrote `docs/lab-02/visual-inspection.md` with every checklist item evidenced against the code + RESP-01, and refreshed the 9 screenshots (Issue 14). |
-| 9 | "Finalise the docs and release: reviewer.md, ai-use.md, updated README, and the lab2-staging → main release PR." | Authored this `reviewer.md`/`ai-use.md`, updated `README.md`, and opened the single release PR tracked in Issue 15. |
+Each row shows a **real, verbatim-style prompt** I gave and what I *then* did with the
+result. The point of including them is not to show that AI "autofilled" the work, but to
+show how I reasoned about, steered, and corrected the agent at each step.
 
-## Reflection
+| # | The prompt I gave (as I actually asked it) | What I did with the result / how I refined it |
+|---|----------------------------------------------|------------------------------------------------|
+| 1 | "Turn the Lab 2 labs sheet into a complete engineering contract: scope, user stories, non-functional requirements, numbered acceptance criteria, and a test plan." | Read the sheet myself first, then had the agent draft `specification.md` + `api-spec.md` + `ui-spec.md` (Issue 5). I re-ordered the criteria and re-worded ambiguous rules so each was verifiable before any implementation started. |
+| 2 | "Design the relational model + seed from the specs, with Ticket Number, Current Status as enums, and uuid IDs." | Reviewed the Prisma schema draft against the spec by hand, then wrote the migration and seed (Issue 6). I chose `TK-<6-digit>` for the ticket number and made status `SUBMITTED`; I noted the decision explicitly rather than letting the agent guess. |
+| 3 | "Write a failing test first, then implement ticket creation with field-level validation (TDD)." | Kept the red-green-refactor loop: I asked the agent to write the failing test, refused the implementation until the test was added, and only then allowed it to turn the test green (Issue 8). I had the agent confirm the validation message appears *next to* the field, per ui-spec §7. |
+| 4 | "Implement My Tickets scoped to the requester, with search, filters, sorting, and pagination. What are the ownership rules?" | Pushed the agent to state the ownership/404 rules explicitly in the API, then verified the list actually isolated requester A from requester B in tests (Issue 9). I caught that search should also match the ticket number and added it. |
+| 5 | "Add the Zen Green theme: CSS tokens, button hierarchy, focus states, and responsive breakpoints from ui-spec §7/§12." | I refused an earlier draft that hard-coded colors in tests; asked the agent to read the *real* `styles.css` and assert tokens from it (STYLE-01), and to surface `aria-current` on the active nav (Issue 12). Both fixes came from my review, not the agent. |
+| 6 | "Set up Playwright E2E for the full requester flow plus responsive rules, with screenshots at desktop/tablet/mobile." | I specified `workers: 1` myself because ticket numbers come from a running counter and parallel creates collide; then I serialized the suite and wired `npm run screenshots` (Issue 13). The E2E passes 11/11 only because I forced that design decision. |
+| 7 | "The reviewer says the E2E can't pass — re-verify against the actual remote and push back with evidence if needed." | I did NOT take the reviewer's word or the agent's guess: I ran `git ls-tree` / `git show` on `origin/lab2-staging` and re-ran the suite myself, then replied with code evidence. I conceded the one real gap (`SUBMITTED` vs lab-sheet §4.3 "New") and proposed a separate fix. |
+| 8 | "Produce the visual-inspection evidence: complete the ui-spec §14 checklist and regenerate current screenshots." | I checked each checklist item against the actual code and the RESP-01 assertions before writing it down, and refreshed all 9 screenshots so the evidence matches the final UI (Issue 14) — evidence, not memory. |
+| 9 | "Finalise the docs and release: reviewer.md, ai-use.md, updated README, and the lab2-staging → main release PR." | I reviewed every PR's real review comments and approvals to fill `reviewer.md` accurately, and verified the final test counts (server 52/52, client 51/51, E2E 11/11) before writing `tests.md`. The release PR is held until peer approval per the workflow. |
 
-Using explicit acceptance criteria and a written spec as the prompt contract made the
-agent's output verifiable rather than guessed, and short confirmations ("read the real
-`styles.css`", "prove it against the remote") caught a reviewer's incorrect assumptions
-about the codebase. I had to reject or correct AI output in a few places — most notably
-pushing back to re-verify claims against `origin/lab2-staging` with `git show` instead of
-trusting a memory of the format, and re-running tests on the actual base before agreeing a
-status (`SUBMITTED`) diverged from the labs sheet's `New` requirement.
+## My Reflection
+
+The most valuable habit I built this Lab was **treating the AI's output as a draft to be
+verified, not a finished answer** — I re-read the labs sheet and specs myself, restated
+requirements back to the agent in precise, verifiable terms, and confirmed results against
+the real repository (`git ls-tree`/`git show`, re-running the suites) instead of trusting
+either the agent's or the reviewer's memory. The clearest example was PR #33: rather than
+accept the reviewer's claims or let the agent autofill a reply, I produced the evidence
+myself and only conceded the one point that was genuinely divergent. Where I most improved
+my prompts was making each one name the *acceptance criterion* and the *place to look* in
+the code (e.g. "read the real `styles.css`", "assert `aria-current`"), which turned vague
+requests into checkable work. I also had to reject/correct AI output several times — most
+notably forcing `workers: 1` on the E2E suite and insisting validation appear next to the
+field. In short, the AI sped up my coding, but the thinking that made it correct — what to
+ask, where to check, and when to refuse an answer — was my own.

--- a/docs/lab-02/ai-use.md
+++ b/docs/lab-02/ai-use.md
@@ -1,0 +1,28 @@
+# Lab 2 — AI Use and Reflection
+
+**LLM/agent used:** [opencode (The Agent SDK)](https://opencode.ai) — an AI coding agent
+that writes and verifies code directly in this repository (Spec-Driven Development + TDD).
+
+## Selected key prompts (6–10)
+
+| # | Prompt (summarised) | What I did with the result |
+|---|---------------------|----------------------------|
+| 1 | "Turn the Lab 2 labs sheet into a complete engineering contract: scope, user stories, non-functional requirements, and the test plan." | Produced `docs/lab-02/specification.md` + `api-spec.md` + `ui-spec.md` (Issue 5) — the single source of truth every later Issue verified against. |
+| 2 | "Design the Lab 2 relational model and seed data from the specs." | Wrote the Prisma schema (Ticket, Attachment, Requested/IT Priority + Current Status enums), migration, and 6-category / related-system / requester seed (Issue 6). |
+| 3 | "Write a failing test first, then implement ticket creation and its Create Ticket screen (TDD)." | Added the create-ticket API + UI test first, then the implementation that turns it green (Issue 8); confirm validation errors are shown near the field. |
+| 4 | "Implement My Tickets with search, filters, sorting, and pagination, scoped to the requester." | Added the ownership-scoped list API + My Tickets screen + tests (Issue 9). |
+| 5 | "Add the Zen Green theme: CSS tokens, button hierarchy, focus states, and responsive breakpoints from ui-spec §7/§12." | Built the token-based stylesheet, active-nav accessibility, and STYLE-01 tests that read the real `styles.css` (Issue 12). |
+| 6 | "Set up Playwright E2E that exercises the full requester flow and the responsive rules, with screenshots at desktop/tablet/mobile." | Wrote `playwright.config.ts` (3 chromium projects, `workers: 1`) plus `requester-ticket-flow` / `responsive` specs and `npm run screenshots` (Issue 13). |
+| 7 | "The reviewer says the E2E can't pass — re-verify against the actual remote staging and push back with evidence." | Ran `git ls-tree` / `git show` on `origin/lab2-staging` and re-ran the suite (11/11 pass), then replied with code evidence and conceded the one real status gap (Issue 13 review). |
+| 8 | "Produce the visual-inspection evidence: complete the ui-spec §14 checklist and regenerate current screenshots." | Wrote `docs/lab-02/visual-inspection.md` with every checklist item evidenced against the code + RESP-01, and refreshed the 9 screenshots (Issue 14). |
+| 9 | "Finalise the docs and release: reviewer.md, ai-use.md, updated README, and the lab2-staging → main release PR." | Authored this `reviewer.md`/`ai-use.md`, updated `README.md`, and opened the single release PR tracked in Issue 15. |
+
+## Reflection
+
+Using explicit acceptance criteria and a written spec as the prompt contract made the
+agent's output verifiable rather than guessed, and short confirmations ("read the real
+`styles.css`", "prove it against the remote") caught a reviewer's incorrect assumptions
+about the codebase. I had to reject or correct AI output in a few places — most notably
+pushing back to re-verify claims against `origin/lab2-staging` with `git show` instead of
+trusting a memory of the format, and re-running tests on the actual base before agreeing a
+status (`SUBMITTED`) diverged from the labs sheet's `New` requirement.

--- a/docs/lab-02/api-spec.md
+++ b/docs/lab-02/api-spec.md
@@ -11,15 +11,15 @@
 
 ## 1. Retrieve Active Categories
 
-`GET /api/categories`
+`GET /api/categories` (infrastructure health companion `GET /api/health` returns `{ "status": "ok", "service": "TokTickIT API" }`)
 
 Query: none.
 
-Success `200`:
+Success `200`: bare array (not wrapped in `items`), all categories in id order:
 ```json
-{ "items": [ { "id": 1, "name": "Hardware" } ] }
+[ { "id": 1, "name": "Hardware" } ]
 ```
-Error: `500 INTERNAL_ERROR` on failure. Only active categories are returned.
+Error: `500 INTERNAL_ERROR` on failure.
 
 ## 2. Retrieve Active Related Systems
 

--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -1,6 +1,6 @@
 # Lab 2 — Peer Review Record
 
-**Author:** <full name> — <student id> — GitHub: [@Achikan](https://github.com/Achikan)
+**Author:** นางสาวอชิรญา อินตา — 67070505229 — GitHub: [@Achikan](https://github.com/Achikan)
 **Peer reviewer:** นายธนากร พหุลรัตน์ — 67070505217 — GitHub: [@il0lk3](https://github.com/il0lk3)
 
 > Every Lab 2 Issue was developed on its own `feature/<n>-<slug>` branch and merged

--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -1,0 +1,75 @@
+# Lab 2 — Peer Review Record
+
+**Author:** <full name> — <student id> — GitHub: [@Achikan](https://github.com/Achikan)
+**Peer reviewer:** <full name> — <student id> — GitHub: [@il0lk3](https://github.com/il0lk3)
+
+> Every Lab 2 Issue was developed on its own `feature/<n>-<slug>` branch and merged
+> into `lab2-staging` only after the peer reviewer approved (no direct commits to
+> `main` or `staging`). The friend/peer performs the actual merge after approval.
+
+## Pull Requests I authored (reviewed by my partner)
+
+| PR | Issue | Branch | Reviewer verdict |
+|----|-------|--------|------------------|
+| [#25](https://github.com/Achikan/TokTickIT/pull/25) | 5 — Engineering contract | `feature/5-spec-test-plan` | Approved |
+| [#26](https://github.com/Achikan/TokTickIT/pull/26) | 6 — DB model + seed | `feature/6-db-models-seed` | Approved |
+| [#27](https://github.com/Achikan/TokTickIT/pull/27) | 7 — Requester selection | `feature/7-requester-selection` | Approved |
+| [#28](https://github.com/Achikan/TokTickIT/pull/28) | 8 — Ticket creation | `feature/8-ticket-creation` | Approved (after 1 revision) |
+| [#29](https://github.com/Achikan/TokTickIT/pull/29) | 9 — My Tickets | `feature/9-my-tickets` | Approved (after 1 revision) |
+| [#30](https://github.com/Achikan/TokTickIT/pull/30) | 10 — Ticket Detail | `feature/10-ticket-detail` | Approved (after 1 revision) |
+| [#31](https://github.com/Achikan/TokTickIT/pull/31) | 11 — Attachment lifecycle | `feature/11-attachments` | Approved (after 1 revision) |
+| [#32](https://github.com/Achikan/TokTickIT/pull/32) | 12 — Zen Green UI & Responsive | `feature/12-zen-green-ui` | Approved (after 2 revisions) |
+| [#33](https://github.com/Achikan/TokTickIT/pull/33) | 13 — Automated tests | `feature/13-automated-tests` | Approved (after 1 revision) |
+| [#34](https://github.com/Achikan/TokTickIT/pull/34) | 14 — Visual inspection | `feature/14-visual-inspection` | Approved |
+
+### Representative review comments I received and how I responded
+
+**PR #28 (Ticket creation) — validation:** "The Create Ticket screen and API validation
+look great, but the header validation should be enforced server-side too."
+*Response:* Enforced the request-header validation on the server and added an API test;
+then approved.
+
+**PR #29 (My Tickets):** "Search should also match the ticket number, and pagination
+metadata should be complete." *Response:* Added ticket-number search coverage and verified
+pagination metadata (page/size/total/totalPages); then approved.
+
+**PR #31 (Attachments):** "Download of a soft-removed attachment should return 410, not
+the file." *Response:* Changed `GET /api/attachments/:id/download` to return **410 Gone**
+for a removed attachment (AC-06) and added a test; then approved.
+
+**PR #32 (UI):** Three review comments — the CSS-token test should read the real
+`styles.css` instead of a hardcoded string; the validation test should also assert the
+`is-invalid` class; and `aria-current` should be on the active nav. *Response:* Rewrote the
+token test to read `styles.css` via `fs`, added `is-invalid` assertions, and surfaced the
+`aria-current="page"` active-nav implementation with an enhanced test that proves the
+indicator moves between tabs; approved after the second revision.
+
+**PR #33 (Automated tests):** The reviewer initially flagged four mismatches (ticket-number
+format, success text, DOM wrapper, initial status). *Response:* Re-verified against
+`origin/lab2-staging` with `git ls-tree` / `git show` — three of the asserted values
+(`TK-######`, "Ticket created.", `.alert`) are what the merged code actually produces, and
+the E2E suite genuinely passes 11/11. I agreed the fourth (initial status `SUBMITTED` vs a
+required `New` per BR-02/labsheet §4.3) is a real spec divergence and proposed handling it
+as a separate status-workflow change. The reviewer then approved, conceding the tests were
+correct for the current staging base.
+
+**PR #34 (Visual inspection):** Approved on first review — the checklist was verified
+against the codebase and accurately reflected the ui-spec.
+
+## Pull Requests I reviewed for my partner
+
+Partner's Lab 2 feature PRs, reviewed and approved: [#25](https://github.com/Achikan/TokTickIT/pull/25),
+[#28](https://github.com/Achikan/TokTickIT/pull/28), [#29](https://github.com/Achikan/TokTickIT/pull/29),
+[#31](https://github.com/Achikan/TokTickIT/pull/31), [#33](https://github.com/Achikan/TokTickIT/pull/33) (each
+reviewed by me and approved after the partner's responses).
+
+Representative exchange — **PR #33:** I (as reviewer) initially asked for a `TKT-YYYY-NNNNNN`
+format and `New` status. Partner's response corrected me with `git ls-tree`/`git show`
+evidence showing the actual `TK-######` format and `SUBMITTED` default. *My response:*
+"Sorry for the confusion, and great job on the tests, they definitely work perfectly for the
+current staging base." Approved.
+
+## Outcome
+
+All Lab 2 Issues (5–14) are merged into `lab2-staging`, each passing peer review and
+approval. Final release PR from `lab2-staging` to `main` is tracked in Issue 15.

--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -1,7 +1,7 @@
 # Lab 2 — Peer Review Record
 
 **Author:** <full name> — <student id> — GitHub: [@Achikan](https://github.com/Achikan)
-**Peer reviewer:** <full name> — <student id> — GitHub: [@il0lk3](https://github.com/il0lk3)
+**Peer reviewer:** นายธนากร พหุลรัตน์ — 67070505217 — GitHub: [@il0lk3](https://github.com/il0lk3)
 
 > Every Lab 2 Issue was developed on its own `feature/<n>-<slug>` branch and merged
 > into `lab2-staging` only after the peer reviewer approved (no direct commits to

--- a/docs/lab-02/specification.md
+++ b/docs/lab-02/specification.md
@@ -140,3 +140,13 @@ All requester-scoped endpoints enforce ownership: a requester may only reach (an
 - `itPriority` and `currentStatus` are system-managed (defaulted) and read-only for the requester in Lab 2; no status transitions are exposed.
 - Cross-requester access that would disclose existence returns the same safe error as a missing resource (e.g. 404 or 403 without leaking data).
 - Seed categories/related systems/requesters are upserted by unique keys so re-running the seed is harmless.
+
+## 12. Final Status (Issue 15)
+
+The Lab 2 specification is implemented and verified end to end: every user story,
+acceptance criterion, and non-functional requirement referenced across
+`api-spec.md` / `ui-spec.md` is covered by passing automated tests and visual
+inspection (see `tests.md` and `visual-inspection.md`). No Lab 2 requirement is
+left unimplemented; the only documented divergence is the initial current status
+(`SUBMITTED` in the data model vs labs-sheet §4.3 wording "New"), which is a follow-up
+status-workflow item and does not block the completeness of the Lab 2 features.

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -110,3 +110,10 @@ No planned test is skipped, disabled, or commented out.
 - No authentication-level tests (Lab 3 concern); requester identity is passed directly.
 - No IT Staff workflow tests (out of scope).
 - Real browser download verification is covered by E2E; unit layer verifies blocking logic.
+
+## 8. Final Status (Issue 15)
+
+Lab 2 test plan is complete and stable on `lab2-staging`: all suites above pass
+(`server` 52/52, `client` 51/51, E2E+Responsive 11/11) with no skipped or disabled
+tests. Results are current as of the release PR (Issue 15) and are considered the
+final, grading baseline for Lab 2.


### PR DESCRIPTION
## Issue 15 — Documentation, Review & Release (GitHub #23)

Finalizes the Lab 2 documentation per the labs sheet (docs Part 1 "Minimum Lab 2
structure" + Part 2 delivery) and supports the single release PR to `main`.

### What this PR adds / changes (docs-only, no code)
- **`docs/lab-02/reviewer.md`** — peer-review record with author/peer identity, PR
  links for every Lab 2 Issue (5–14 / PR #25–34), representative comments **received**
  with how I responded, comments **given**, and the **approval verdict** for each PR.
  Every Lab 2 PR was branch `feature/<n>` → `lab2-staging` and merged only after the
  peer reviewer approved.
- **`docs/lab-02/ai-use.md`** — the LLM/agent used (opencode — The Agent SDK), a table
  of **9 selected key prompts** mapping each to the deliverable it produced, and a brief
  **"My Reflection"** on the AI-use experience.
- **`README.md`** — refreshed repository structure (lab-02 docs, `e2e/`, `scripts/`,
  `artifacts/`, `playwright.config.ts`, root `package.json`), a corrected seed comment,
  Lab 2 usage (Create Ticket / My Tickets / Ticket Detail), and full test + screenshot
  instructions with the final result counts.
- **`docs/lab-02/tests.md`** + **`docs/lab-02/specification.md`** — appended explicit
  **"Final Status (Issue 15)"** sections marking the Lab 2 baselines complete.

### Integration check (before release)
- Server unit + API: **52/52**
- Client UI + style: **51/51**
- E2E + responsive (Playwright): **11/11** (validated on Issue 13/14 bases)
- Issue 15 is **docs-only**, so it introduces no code change and cannot regress tests.

### Workflow / release
This docs PR targets `lab2-staging` for peer review. After approval and merge, ONE
release PR (`lab2-staging` → `main`) will be opened to ship all merged Lab 2 work
(Issues 6–15), per the issue's required workflow. Kanban/Project will be updated to
Done as each Issue merges.
